### PR TITLE
fix(init): nested hook schema + honor CLAUDE_CONFIG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ ctx stats     # Block count, categories, storage
 ```json
 {
   "hooks": {
-    "SubagentStart": [{ "type": "command", "command": "ctx brief --hook" }],
-    "SubagentStop":  [{ "type": "command", "command": "ctx persist --hook" }]
+    "SubagentStart": [{ "hooks": [{ "type": "command", "command": "ctx brief --hook" }] }],
+    "SubagentStop":  [{ "hooks": [{ "type": "command", "command": "ctx persist --hook" }] }]
   }
 }
 ```

--- a/go/internal/cli/brief.go
+++ b/go/internal/cli/brief.go
@@ -65,7 +65,7 @@ Setup (add to ~/.claude/settings.json):
   {
     "hooks": {
       "SubagentStart": [
-        { "type": "command", "command": "ctx brief --hook" }
+        { "hooks": [ { "type": "command", "command": "ctx brief --hook" } ] }
       ]
     }
   }`,

--- a/go/internal/cli/init.go
+++ b/go/internal/cli/init.go
@@ -80,6 +80,12 @@ func promptYesNo(question string) bool {
 // ── Claude settings.json path ──────────────────────────────────────.
 
 func claudeSettingsPath() string {
+	// CLAUDE_CONFIG_DIR relocates Claude Code's entire config directory; when it
+	// is set, the live settings file is $CLAUDE_CONFIG_DIR/settings.json and
+	// ~/.claude/settings.json is not read. Honor it before any home-relative path.
+	if dir := os.Getenv("CLAUDE_CONFIG_DIR"); dir != "" {
+		return filepath.Join(dir, "settings.json")
+	}
 	if runtime.GOOS == "windows" {
 		if profile := os.Getenv("USERPROFILE"); profile != "" {
 			return filepath.Join(profile, ".claude", "settings.json")
@@ -276,16 +282,22 @@ func (s *settingsJSON) save(path string) error {
 	return os.WriteFile(path, data, 0o600)
 }
 
-// hasHookEntry checks if any entry in the hook array contains the given command substring.
+// hasHookEntry reports whether any entry in the hook array contains the given
+// command substring. It handles both the legacy flat form
+// {"type":"command","command":…} and the current nested matcher-group form
+// {"hooks":[{"type":"command","command":…}]}, so detection stays idempotent
+// against either shape and re-running init does not append duplicates.
 func hasHookEntry(hooks []any, cmdSubstr string) bool {
 	for _, entry := range hooks {
 		m, ok := entry.(map[string]any)
 		if !ok {
 			continue
 		}
-		cmd, _ := m["command"].(string)
-		if strings.Contains(cmd, cmdSubstr) {
-			return true
+		if cmd, _ := m["command"].(string); strings.Contains(cmd, cmdSubstr) {
+			return true // legacy flat form
+		}
+		if inner, ok := m["hooks"].([]any); ok && hasHookEntry(inner, cmdSubstr) {
+			return true // nested matcher-group form
 		}
 	}
 	return false
@@ -308,6 +320,18 @@ func getHookArray(hooks map[string]any, event string) []any {
 		return nil
 	}
 	return arr
+}
+
+// newHookGroup builds the nested matcher-group form Claude Code requires for a
+// hook event: {"hooks":[{"type":"command","command":cmd}]}. The "matcher" key is
+// omitted on purpose — SubagentStart/SubagentStop are not tool-scoped events. A
+// bare {"type":"command",…} without this wrapper is silently ignored.
+func newHookGroup(cmd string) map[string]any {
+	return map[string]any{
+		"hooks": []any{
+			map[string]any{"type": "command", "command": cmd},
+		},
+	}
 }
 
 func stepHooks() bool {
@@ -345,21 +369,13 @@ func stepHooks() bool {
 		return false
 	}
 
-	// Add missing hooks
+	// Add missing hooks in the nested matcher-group form (see newHookGroup).
 	if !hasStart {
-		entry := map[string]any{
-			"type":    "command",
-			"command": hookCmdBrief,
-		}
-		startArr = append(startArr, entry)
+		startArr = append(startArr, newHookGroup(hookCmdBrief))
 		hooksMap["SubagentStart"] = startArr
 	}
 	if !hasStop {
-		entry := map[string]any{
-			"type":    "command",
-			"command": hookCmdPersist,
-		}
-		stopArr = append(stopArr, entry)
+		stopArr = append(stopArr, newHookGroup(hookCmdPersist))
 		hooksMap["SubagentStop"] = stopArr
 	}
 

--- a/go/internal/cli/init_test.go
+++ b/go/internal/cli/init_test.go
@@ -87,19 +87,47 @@ func TestDisplayConfigPath(t *testing.T) {
 }
 
 func TestHasHookEntry(t *testing.T) {
-	hooks := []any{
+	// legacy flat form (still detected for backward compatibility)
+	flat := []any{
 		map[string]any{"type": "command", "command": "ctx brief --hook"},
 		map[string]any{"type": "command", "command": "some-other-cmd"},
 	}
 
-	if !hasHookEntry(hooks, "ctx brief") {
-		t.Error("should find 'ctx brief' in hooks")
+	if !hasHookEntry(flat, "ctx brief") {
+		t.Error("should find 'ctx brief' in flat hooks")
 	}
-	if hasHookEntry(hooks, "ctx persist") {
-		t.Error("should not find 'ctx persist' in hooks")
+	if hasHookEntry(flat, "ctx persist") {
+		t.Error("should not find 'ctx persist' in flat hooks")
 	}
 	if hasHookEntry(nil, "anything") {
 		t.Error("nil hooks should return false")
+	}
+
+	// current nested matcher-group form
+	nested := []any{newHookGroup("ctx persist --hook")}
+	if !hasHookEntry(nested, "ctx persist") {
+		t.Error("should find 'ctx persist' in nested matcher-group hooks")
+	}
+	if hasHookEntry(nested, "ctx brief") {
+		t.Error("should not find 'ctx brief' in nested hooks")
+	}
+}
+
+func TestNewHookGroup(t *testing.T) {
+	g := newHookGroup("ctx brief --hook")
+	inner, ok := g["hooks"].([]any)
+	if !ok || len(inner) != 1 {
+		t.Fatalf("newHookGroup should wrap one entry under \"hooks\", got %#v", g)
+	}
+	entry, ok := inner[0].(map[string]any)
+	if !ok {
+		t.Fatalf("inner entry should be a map, got %#v", inner[0])
+	}
+	if entry["type"] != "command" || entry["command"] != "ctx brief --hook" {
+		t.Errorf("unexpected inner entry: %#v", entry)
+	}
+	if !hasHookEntry([]any{g}, "ctx brief") {
+		t.Error("hasHookEntry should detect a newHookGroup entry")
 	}
 }
 
@@ -127,7 +155,7 @@ func TestLoadSettings_ExistingFile(t *testing.T) {
 	content := `{
   "customSlashCommands": [{"name": "test"}],
   "hooks": {
-    "SubagentStart": [{"type": "command", "command": "existing-cmd"}]
+    "SubagentStart": [{"hooks": [{"type": "command", "command": "existing-cmd"}]}]
   }
 }`
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
@@ -185,9 +213,7 @@ func TestSettingsSave_PreservesExisting(t *testing.T) {
 
 	// Add hooks
 	hooks := s.getHooksMap()
-	hooks["SubagentStart"] = []any{
-		map[string]any{"type": "command", "command": hookCmdBrief},
-	}
+	hooks["SubagentStart"] = []any{newHookGroup(hookCmdBrief)}
 
 	if err := s.save(path); err != nil {
 		t.Fatal(err)
@@ -249,12 +275,22 @@ func TestGetHooksMap_CreatesIfMissing(t *testing.T) {
 }
 
 func TestClaudeSettingsPath(t *testing.T) {
+	// Default (no CLAUDE_CONFIG_DIR): home-relative ~/.claude/settings.json.
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	path := claudeSettingsPath()
 	if path == "" {
 		t.Error("claudeSettingsPath() returned empty string")
 	}
 	if !contains(path, ".claude") || !contains(path, "settings.json") {
 		t.Errorf("claudeSettingsPath() = %q, expected .claude/settings.json", path)
+	}
+
+	// CLAUDE_CONFIG_DIR set: settings live directly under it (no ~/.claude).
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	want := filepath.Join(dir, "settings.json")
+	if got := claudeSettingsPath(); got != want {
+		t.Errorf("claudeSettingsPath() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Fixes #5.

`ctx init` reported `Hooks ✓` while writing hooks that never execute. As verified in the issue, two independent defects combined (flat hook schema that current Claude Code silently ignores; hardcoded `~/.claude/settings.json` that ignores `CLAUDE_CONFIG_DIR`), plus a non-idempotent `hasHookEntry`.

## Changes

**`go/internal/cli/init.go`**
- `claudeSettingsPath()` now honors `CLAUDE_CONFIG_DIR`: returns `$CLAUDE_CONFIG_DIR/settings.json` when set, else `~/.claude/settings.json` (the Windows `%USERPROFILE%` branch is retained). Per your review, the originally-proposed `~/.config/claude-code` fallback was **dropped** — the resolver is exactly `CLAUDE_CONFIG_DIR`-or-`~/.claude`. This also fixes the statusline step (shared resolver).
- New `newHookGroup(cmd)` helper emits the nested matcher-group form `{"hooks":[{"type":"command","command":cmd}]}`; `stepHooks()` now writes that instead of the silently-ignored flat form.
- `hasHookEntry()` recurses into a nested `hooks[]` (in addition to the legacy flat form), so re-running `init` is idempotent against both shapes and no longer appends duplicates.

**Docs** — nested the hook examples in `README.md` §3 and the `brief.go` `--hook` help. (The `statusLine` examples were already the correct shape and are left unchanged.)

**Tests** (`go/internal/cli/init_test.go`)
- `TestHasHookEntry` keeps the legacy-flat cases and adds nested-form detection.
- New `TestNewHookGroup`.
- `TestClaudeSettingsPath` now covers both branches (unset → `~/.claude`; set → `$CLAUDE_CONFIG_DIR/settings.json`).
- Updated the `TestLoadSettings_ExistingFile` and `TestSettingsSave_PreservesExisting` fixtures to the nested form.

## Verification
- `gofmt -l` clean on the changed files; `go vet ./...` and `go build ./...` clean.
- `go test ./internal/cli/` passes, including the new/updated tests.

> Note: the broader repo shows pre-existing `gofmt` drift under go1.26.0's `gofmt` (unrelated files). I left those untouched to keep this PR scoped to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
