### PR TITLE
fix(health): cloud API backends report false-negative on /health

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,6 +34,17 @@ else's environment — that led to a fix landing in the repository.
   hardcoded `~/.claude/settings.json` that ignored `CLAUDE_CONFIG_DIR`. A/B/A
   probe-script reproduction isolating schema-vs-path, root-cause to the exact
   functions, and a verified fix delivered as a pull request.
+- **TurgutKural** ([@TurgutKural](https://github.com/TurgutKural)) — PR
+  [#9](https://github.com/GottZ/ctx/pull/9): `/health` reported every cloud
+  inference backend as down. The probe demanded HTTP 200 on `GET /`, which only
+  local servers (llama.cpp, Ollama) answer — cloud APIs route nothing at their
+  root and reply 404/405, so a perfectly healthy backend read as unreachable.
+  Diagnosis and a pull request; the shipped fix keeps the reachability
+  semantics he identified (any response below 500) and drops the credentials
+  from the probe. Also PR
+  [#10](https://github.com/GottZ/ctx/pull/10): `dream.language`, a hot-mutable
+  server setting that makes the daily-synthesis report language configurable
+  instead of hardcoded.
 
 ## How to be listed
 

--- a/go/internal/handler/health.go
+++ b/go/internal/handler/health.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -217,8 +216,11 @@ func (h *HealthHandler) Health(w http.ResponseWriter, r *http.Request) {
 }
 
 // roleReachable reports ok when at least one enabled backend of the role
-// answers its base URL. Errors log the backend name to slog ONLY — the
-// response carries the aggregate.
+// answers its base URL. This is a REACHABILITY probe, not a model-availability
+// check: any HTTP response below 500 counts as reachable — cloud API roots
+// answer 404/405 on GET / and auth-gated APIs answer 401/403, all of which
+// prove the host is up and serving (see pingHost). Errors log the backend name
+// to slog ONLY — the response carries the aggregate.
 func roleReachable(ctx context.Context, snap []backends.Backend, role string) string {
 	candidates := 0
 	for i := range snap {
@@ -227,7 +229,7 @@ func roleReachable(ctx context.Context, snap []backends.Backend, role string) st
 			continue
 		}
 		candidates++
-		if err := pingBackend(ctx, b); err != nil {
+		if err := pingHost(ctx, b.Host); err != nil {
 			slog.Warn("health check: backend ping failed", "backend", b.Name, "role", role, "error", err)
 			continue
 		}
@@ -239,50 +241,40 @@ func roleReachable(ctx context.Context, snap []backends.Backend, role string) st
 	return "error"
 }
 
-// pingBackend probes a backend through two strategies, requiring HTTP 200:
+// pingHost issues ONE credential-free GET against the backend's base URL and
+// decides reachability by status class: every HTTP response below 500 means
+// "the host is up and serving", 5xx and transport failures (DNS, connection
+// refused, timeout) mean unreachable.
 //
-//	Phase 1: GET {host}           → 200 for local servers (llama.cpp, Ollama)
-//	Phase 2: GET {host}/v1/models → 200 for OpenAI-compatible cloud APIs
+// Why < 500 instead of == 200 (PR #9, cloud-API false negative): only local
+// servers (llama.cpp, Ollama) answer 200 on GET /. Cloud inference APIs route
+// nothing at the root and answer 404/405 (Voyage, OpenAI-compatible
+// gateways), and an auth-gated API answers 401/403 to an anonymous probe. All
+// of those are HTTP responses from a live host — treating them as "down"
+// marked every cloud backend permanently unhealthy. /health aggregates
+// reachability only; whether a MODEL is servable is the chain's business, not
+// this probe's.
 //
-// Both phases send the backend's configured auth headers. Only HTTP 200
-// counts as reachable.
-func pingBackend(ctx context.Context, b *backends.Backend) error {
-	// Phase 1: GET base URL (local llama.cpp / Ollama servers).
-	if err := doPing(ctx, b, http.MethodGet, b.Host, nil); err == nil {
-		return nil
-	}
+// Why credential-free: /health is unauthenticated, uncached and public, so
+// every byte this function sends is attacker-triggerable egress. Sending the
+// backend's Authorization/ExtraHeaders here would push real credentials to
+// third-party hosts (and across their redirects) on an anonymous request,
+// bypassing the chain egress gates in backends.Pool (VisibleTo/disabledBy/
+// Trust) that guard genuine inference traffic. An anonymous probe answers the
+// health question without ever putting a secret on the wire — a 401 is proof
+// of life just like a 200. Keep it that way.
+//
+// The returned error carries the cause class ("status 503" vs. the wrapped
+// transport error) because it is the only diagnostic the /health warn log has.
+func pingHost(ctx context.Context, host string) error {
+	url := strings.TrimRight(host, "/")
 
-	// Phase 2: GET /v1/models (OpenAI-compatible cloud APIs).
-	modelsURL := strings.TrimRight(b.Host, "/") + "/v1/models"
-	if err := doPing(ctx, b, http.MethodGet, modelsURL, nil); err == nil {
-		return nil
-	}
-
-	return fmt.Errorf("no health endpoint returned 200 for %s", b.Host)
-}
-
-// doPing sends a single HTTP request with the backend's auth headers and
-// returns nil only on HTTP 200.
-func doPing(ctx context.Context, b *backends.Backend, method, url string, body []byte) error {
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader) //nolint:gosec // G704: pool row, admin-gated.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) //nolint:gosec // G704: host is a context_backends pool row (admin-gated, locality-validated), not free user input — same false positive as the Do() below. The G34 SSE path (HandleEvents → Snapshot(r.Context()) → HealthStatus → roleReachable → pingHost) lets gosec's taint analysis reach this line too. Since the probe carries no credentials, an SSRF through a poisoned pool row cannot exfiltrate a backend secret either.
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
-	for k, v := range b.ExtraHeaders {
-		req.Header.Set(k, v)
-	}
-	if b.APIKey != "" && req.Header.Get("Authorization") == "" {
-		req.Header.Set("Authorization", "Bearer "+b.APIKey)
-	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
 
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: pool rows are admin-gated runtime data.
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: pool rows are admin-gated runtime data (locality-validated); the request is credential-free, so nothing sensitive travels this hop or its redirect chain.
 	if err != nil {
 		return fmt.Errorf("connecting to host: %w", err)
 	}
@@ -292,8 +284,14 @@ func doPing(ctx context.Context, b *backends.Backend, method, url string, body [
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	// Drain a bounded prefix before Close so the transport can reuse the
+	// connection; an unread body makes it drop the socket. The cap keeps a
+	// chatty/hostile endpoint from streaming into the health path.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+
+	if resp.StatusCode >= http.StatusInternalServerError {
+		return fmt.Errorf("host unhealthy: status %d", resp.StatusCode)
 	}
+
 	return nil
 }

--- a/go/internal/handler/health.go
+++ b/go/internal/handler/health.go
@@ -1,11 +1,14 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/GottZ/ctx/internal/backends"
@@ -224,7 +227,7 @@ func roleReachable(ctx context.Context, snap []backends.Backend, role string) st
 			continue
 		}
 		candidates++
-		if err := pingHost(ctx, b.Host); err != nil {
+		if err := pingBackend(ctx, b); err != nil {
 			slog.Warn("health check: backend ping failed", "backend", b.Name, "role", role, "error", err)
 			continue
 		}
@@ -236,13 +239,50 @@ func roleReachable(ctx context.Context, snap []backends.Backend, role string) st
 	return "error"
 }
 
-func pingHost(ctx context.Context, host string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, host, nil) //nolint:gosec // G704: host is a context_backends pool row (admin-gated, locality-validated), not free user input — same false positive as the Do() below. The G34 SSE path (HandleEvents → Snapshot(r.Context()) → HealthStatus → pingHost) lets gosec's taint analysis reach this line too.
+// pingBackend probes a backend through two strategies, requiring HTTP 200:
+//
+//	Phase 1: GET {host}           → 200 for local servers (llama.cpp, Ollama)
+//	Phase 2: GET {host}/v1/models → 200 for OpenAI-compatible cloud APIs
+//
+// Both phases send the backend's configured auth headers. Only HTTP 200
+// counts as reachable.
+func pingBackend(ctx context.Context, b *backends.Backend) error {
+	// Phase 1: GET base URL (local llama.cpp / Ollama servers).
+	if err := doPing(ctx, b, http.MethodGet, b.Host, nil); err == nil {
+		return nil
+	}
+
+	// Phase 2: GET /v1/models (OpenAI-compatible cloud APIs).
+	modelsURL := strings.TrimRight(b.Host, "/") + "/v1/models"
+	if err := doPing(ctx, b, http.MethodGet, modelsURL, nil); err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("no health endpoint returned 200 for %s", b.Host)
+}
+
+// doPing sends a single HTTP request with the backend's auth headers and
+// returns nil only on HTTP 200.
+func doPing(ctx context.Context, b *backends.Backend, method, url string, body []byte) error {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader) //nolint:gosec // G704: pool row, admin-gated.
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
+	for k, v := range b.ExtraHeaders {
+		req.Header.Set(k, v)
+	}
+	if b.APIKey != "" && req.Header.Get("Authorization") == "" {
+		req.Header.Set("Authorization", "Bearer "+b.APIKey)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: pool rows are admin-gated runtime data (locality-validated)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: pool rows are admin-gated runtime data.
 	if err != nil {
 		return fmt.Errorf("connecting to host: %w", err)
 	}
@@ -255,6 +295,5 @@ func pingHost(ctx context.Context, host string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
 	}
-
 	return nil
 }

--- a/go/internal/handler/health_ping_test.go
+++ b/go/internal/handler/health_ping_test.go
@@ -1,0 +1,192 @@
+// PR #9 contract: the /health backend probe is a REACHABILITY check, not a
+// model-availability check, and it is credential-free. These tests pin both
+// halves of that contract:
+//
+//   - status class decides: < 500 = reachable (200 local server, 404/405 cloud
+//     API root, 401/403 auth-gated API), >= 500 and transport failures = down;
+//   - the probe never carries the backend's Authorization/ExtraHeaders, and it
+//     issues exactly ONE request — /health is unauthenticated and uncached, so
+//     both properties bound what an anonymous poller can make this service emit.
+//
+// Fixture hygiene follows health_test.go: loopback httptest servers and closed
+// loopback ports only (deterministic reachability, no resolver in the path).
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/GottZ/ctx/internal/backends"
+)
+
+// TestPingHostStatusClass pins the reachability semantics per status code.
+// The 404 row is the PR #9 case itself: a cloud API (Voyage and friends)
+// routes nothing at its root and answers 404 — the host is demonstrably up.
+func TestPingHostStatusClass(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		reachable bool
+		wantErr   string
+	}{
+		{name: "200 local server", status: http.StatusOK, reachable: true},
+		{name: "404 cloud api root", status: http.StatusNotFound, reachable: true},
+		{name: "405 method not allowed", status: http.StatusMethodNotAllowed, reachable: true},
+		{name: "401 auth gated api", status: http.StatusUnauthorized, reachable: true},
+		{name: "503 backend down", status: http.StatusServiceUnavailable, reachable: false, wantErr: "status 503"},
+		{name: "500 backend broken", status: http.StatusInternalServerError, reachable: false, wantErr: "status 500"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var hits atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hits.Add(1)
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"detail":"probe body"}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			err := pingHost(context.Background(), srv.URL)
+
+			if tc.reachable && err != nil {
+				t.Errorf("status %d: pingHost = %v, want reachable", tc.status, err)
+			}
+			if !tc.reachable {
+				if err == nil {
+					t.Fatalf("status %d: pingHost = nil, want unreachable", tc.status)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q does not name the cause class %q", err, tc.wantErr)
+				}
+			}
+			// One probe = one request. A multi-phase probe would double the
+			// egress every unauthenticated /health call produces.
+			if got := hits.Load(); got != 1 {
+				t.Errorf("%d requests for one probe, want 1", got)
+			}
+		})
+	}
+}
+
+// TestPingHostTransportFailure pins that a refused connection is unreachable
+// AND that the wrapped transport error survives into the /health warn log —
+// the only diagnostic that path has.
+func TestPingHostTransportFailure(t *testing.T) {
+	err := pingHost(context.Background(), closedPortHost(t))
+	if err == nil {
+		t.Fatal("pingHost on a closed port = nil, want unreachable")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "connecting to host") {
+		t.Errorf("error %q does not classify the failure as a transport error", msg)
+	}
+	if !strings.Contains(msg, "connect") && !strings.Contains(msg, "refused") {
+		t.Errorf("error %q drops the underlying transport cause", msg)
+	}
+}
+
+// TestPingHostTrimsTrailingSlash pins the base-URL normalisation: a pool row
+// stored as "http://host/" probes the same target as "http://host".
+func TestPingHostTrimsTrailingSlash(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := pingHost(context.Background(), srv.URL+"/"); err != nil {
+		t.Fatalf("pingHost with trailing slash: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) != 1 {
+		t.Fatalf("%d requests, want 1", len(paths))
+	}
+	if paths[0] != "/" {
+		t.Errorf("probe path = %q, want /", paths[0])
+	}
+}
+
+// TestRoleReachableProbeIsCredentialFree is the security half of the PR #9
+// contract: even a backend that carries an API key AND provider headers must
+// be probed anonymously. /health is unauthenticated — anything the probe sends
+// is egress an anonymous caller can trigger, so no secret may ride along, and
+// the probe must not multiply into several requests.
+func TestRoleReachableProbeIsCredentialFree(t *testing.T) {
+	var hits atomic.Int32
+	var mu sync.Mutex
+	var seen http.Header
+	var seenPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		mu.Lock()
+		seen = r.Header.Clone()
+		seenPath = r.URL.Path
+		mu.Unlock()
+		// A cloud API root: nothing served here, host clearly alive.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	snap := []backends.Backend{{
+		ID: "cloud", Name: "needle-backend-cloud", Host: srv.URL, Enabled: true,
+		Trust: backends.TrustFull, Roles: []string{backends.RoleEmbed},
+		APIKey: "sk-needle-must-never-egress-0123456789",
+		ExtraHeaders: map[string]string{
+			"X-Api-Key":         "needle-extra-key",
+			"Anthropic-Version": "2023-06-01",
+		},
+	}}
+
+	if got := roleReachable(context.Background(), snap, backends.RoleEmbed); got != "ok" {
+		t.Errorf("roleReachable on a 404-answering cloud root = %q, want ok (PR #9 false negative)", got)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("%d requests for one backend, want exactly 1", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if seenPath != "/" {
+		t.Errorf("probe path = %q, want / (no /v1/models phase)", seenPath)
+	}
+	if v := seen.Get("Authorization"); v != "" {
+		t.Errorf("probe carried Authorization %q — credentials must never leave via /health", v)
+	}
+	for _, k := range []string{"X-Api-Key", "Anthropic-Version"} {
+		if v := seen.Get(k); v != "" {
+			t.Errorf("probe carried backend ExtraHeader %s=%q — the probe must stay anonymous", k, v)
+		}
+	}
+}
+
+// TestRoleReachableFiveXXIsDown pins that a 5xx backend does not count as a
+// reachable role: the status class is the whole gate, and an overloaded or
+// broken host must still surface as "error".
+func TestRoleReachableFiveXXIsDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(srv.Close)
+
+	snap := []backends.Backend{{
+		ID: "broken", Name: "needle-backend-broken", Host: srv.URL, Enabled: true,
+		Trust: backends.TrustFull, Roles: []string{backends.RoleEmbed},
+	}}
+
+	if got := roleReachable(context.Background(), snap, backends.RoleEmbed); got != "error" {
+		t.Errorf("roleReachable on a 502 host = %q, want error", got)
+	}
+}


### PR DESCRIPTION
## Problem

`/health` reports `embed: error` and `chat: error` (→ HTTP 503) even when all backends are fully operational.

**Root cause:** `pingHost` sends a plain `GET` to the backend's `base_url` and requires HTTP 200. Cloud API providers do not serve a root page:

| Provider | `GET {base_url}` | Actual status |
|---|---|---|
| `api.voyageai.com` | 404 | Operational (POST-only API) |
| `opencode.ai/zen/go` | 404 | Operational |
| Local llama.cpp | 200 | Operational |

The reference deployment uses only local llama.cpp sidecars (which return 200 on `GET /`), so this was never hit upstream.

## Fix

Replace `pingHost(ctx, host)` with `pingBackend(ctx, *Backend)` — a two-phase probe that sends the backend's configured auth headers:

1. **Phase 1:** `GET {host}` → 200 for local servers (llama.cpp, Ollama)
2. **Phase 2:** `GET {host}/v1/models` → 200 for OpenAI-compatible cloud APIs

Only HTTP 200 counts as reachable — the status-code gate is preserved. Connection-level failures (timeout, DNS, refused) remain errors.

## Not covered

POST-only APIs with no GET endpoint returning 200 (e.g. Voyage) will still report `error`. For those, a local Ollama/llama.cpp embed backend is the recommended path.

## Tested

- llama.cpp sidecar → Phase 1 pass ✓
- opencode.ai → Phase 2 pass ✓
- Ollama (local) → Phase 1 pass ✓
- `/health` returns `{"status":"ok"}` with all backends active ✓