### PR TITLE
fix(dream): parse string-map link drift from deepseek-v4-flash

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,7 +48,13 @@ else's environment — that led to a fix landing in the repository.
   [#11](https://github.com/GottZ/ctx/pull/11): cloud relays answer the dream
   link prompt in a named-wrapper drift form (`{"analysis": [...]}`) that the
   parser rejected; the shipped fix keeps his parser-side solution and leaves
-  the wire format untouched.
+  the wire format untouched. Also PR
+  [#12](https://github.com/GottZ/ctx/pull/12): a fifth link-response drift
+  form — deepseek-v4-flash collapses the array into a bare `{"<uuid>":
+  "<type>"}` string map with no confidence field, losing every link in the
+  cycle; the shipped fix keeps his recover-the-type approach and floor
+  doctrine, hardened with entry discrimination so prose envelopes still
+  surface as retryable parse errors.
 
 ## How to be listed
 

--- a/go/internal/dream/dream_test.go
+++ b/go/internal/dream/dream_test.go
@@ -999,6 +999,29 @@ func TestAcceptCausal(t *testing.T) {
 	}
 }
 
+// TestParseLinks_StringMap_SurvivesFilterPipeline runs the string-map form
+// through the ACTUAL downstream gate (filterValidCandidates) instead of only
+// asserting parser output — the review found every string-map test stopped at
+// the parser while the real failure modes (uuid gate, per-type confidence
+// floor) live one call later.
+func TestParseLinks_StringMap_SurvivesFilterPipeline(t *testing.T) {
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"topical","019fb98f-cad3-7bbe-b3be-ccf74d5ba05f":"recurrent"}`
+	links, _, err := parseLinks(raw)
+	if err != nil || len(links) != 2 {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+	candidateIDs := map[string]bool{
+		"019fb992-ea5a-7ef8-aa5c-ed7db94699ca": true,
+		"019fb98f-cad3-7bbe-b3be-ccf74d5ba05f": true,
+	}
+	valid := filterValidCandidates(links, candidateIDs)
+	// BOTH must survive: the topical link at floor 0.7 and the recurrent link
+	// at its per-type floor 0.8 (a hardcoded 0.7 would silently lose it here).
+	if len(valid) != 2 {
+		t.Fatalf("string-map links must clear filterValidCandidates, got %d of 2: %+v", len(valid), valid)
+	}
+}
+
 // --- enforceSupersedesDirection Tests ---.
 
 // TestEnforceSupersedesDirection_DowngradesInverted verifies that supersedes
@@ -1025,11 +1048,16 @@ func TestEnforceSupersedesDirection_DowngradesInverted(t *testing.T) {
 		{TargetID: "tgt-invert", Relationship: "causal", Confidence: 0.8},
 	}
 
-	out := enforceSupersedesDirection(links, srcCreated, candidates)
+	out, downgraded := enforceSupersedesDirection(links, srcCreated, candidates)
 
 	// All 5 input links must survive — none are dropped.
 	if len(out) != 5 {
 		t.Fatalf("got %d kept, want 5 (downgrade, never drop)", len(out))
+	}
+	// The downgrade count feeds the supersedes_direction_downgraded telemetry
+	// (previously dead: the caller measured a len-diff that never changes).
+	if downgraded != 2 {
+		t.Errorf("downgrade count: got %d, want 2", downgraded)
 	}
 
 	// Correctly oriented supersedes stays as supersedes.
@@ -1067,9 +1095,12 @@ func TestEnforceSupersedesDirection_KeepsCorrect(t *testing.T) {
 		{TargetID: "tgt", Relationship: "supersedes", Confidence: 0.92},
 	}
 
-	out := enforceSupersedesDirection(links, srcCreated, candidates)
+	out, downgraded := enforceSupersedesDirection(links, srcCreated, candidates)
 	if len(out) != 1 {
 		t.Fatalf("got %d, want 1", len(out))
+	}
+	if downgraded != 0 {
+		t.Errorf("downgrade count: got %d, want 0", downgraded)
 	}
 	if out[0].Relationship != "supersedes" {
 		t.Errorf("relationship changed: got %q, want supersedes", out[0].Relationship)
@@ -1090,7 +1121,7 @@ func TestEnforceSupersedesDirection_UnknownTargetPassThrough(t *testing.T) {
 	links := []Link{
 		{TargetID: "tgt-unknown", Relationship: "supersedes", Confidence: 0.9},
 	}
-	out := enforceSupersedesDirection(links, srcCreated, candidates)
+	out, _ := enforceSupersedesDirection(links, srcCreated, candidates)
 	if len(out) != 1 {
 		t.Fatalf("unknown-target supersedes was dropped by direction filter (must defer to filterValidCandidates)")
 	}
@@ -1102,11 +1133,11 @@ func TestEnforceSupersedesDirection_UnknownTargetPassThrough(t *testing.T) {
 // TestEnforceSupersedesDirection_EmptyInput verifies the filter handles nil
 // and empty inputs without panicking.
 func TestEnforceSupersedesDirection_EmptyInput(t *testing.T) {
-	out := enforceSupersedesDirection(nil, time.Now(), nil)
+	out, _ := enforceSupersedesDirection(nil, time.Now(), nil)
 	if len(out) != 0 {
 		t.Errorf("got %v, want empty/nil", out)
 	}
-	out = enforceSupersedesDirection([]Link{}, time.Now(), []BlockInfo{})
+	out, _ = enforceSupersedesDirection([]Link{}, time.Now(), []BlockInfo{})
 	if len(out) != 0 {
 		t.Errorf("got %d links, want 0", len(out))
 	}

--- a/go/internal/dream/dream_test.go
+++ b/go/internal/dream/dream_test.go
@@ -297,13 +297,87 @@ func TestParseLinks_ObjectForm_GarbageKey(t *testing.T) {
 }
 
 func TestParseLinks_ObjectForm_UnknownStringConf(t *testing.T) {
+	// Contract change (PR #12 review, finding: zero-link contract): the entry
+	// itself is still dropped, but a non-empty map whose EVERY entry drops is
+	// degenerate output and must surface as a parse error (transient retry) —
+	// previously this returned a zero-link success, which books the multi-day
+	// inert cooldown and contradicted TestParseLinks_StringMap_AllEmptyErrors'
+	// contract for the same downstream consequence.
 	raw := `{"id":{"type":"topical","confidence":"vibes"}}`
-	links, _, err := parseLinks(raw)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if _, _, err := parseLinks(raw); err == nil {
+		t.Fatal("map with only unusable entries must be a parse error")
 	}
-	if len(links) != 0 {
-		t.Fatalf("unparseable confidence must drop entry, got %+v", links)
+	// A sibling entry with usable confidence keeps the map parseable; only
+	// the unusable entry is dropped.
+	raw = `{"a":{"type":"topical","confidence":"vibes"},"b":{"type":"factual","confidence":0.9}}`
+	links, _, err := parseLinks(raw)
+	if err != nil || len(links) != 1 || links[0].TargetID != "b" {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+}
+
+func TestParseLinks_ObjectForm_NullValueErrors(t *testing.T) {
+	// {"<uuid>": null} unmarshals into the struct-map form as a zero-value
+	// no-op entry; without the zero-link guard it returned a silent success
+	// (inert cooldown) instead of the transient retry it deserves.
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":null}`
+	if _, _, err := parseLinks(raw); err == nil {
+		t.Fatal("null-valued map entry must be a parse error")
+	}
+}
+
+func TestParseLinks_ObjectForm_MissingConfidenceFloored(t *testing.T) {
+	// Absent confidence (key missing entirely) on a known type takes the
+	// per-type floor — the model committed to a relationship, it just gave no
+	// strength signal (string-map doctrine applied to the object-map form).
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":{"type":"topical"}}`
+	links, _, err := parseLinks(raw)
+	if err != nil || len(links) != 1 {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+	if links[0].Confidence != minRawConfidence["topical"] {
+		t.Fatalf("want per-type floor %.2f, got %.2f", minRawConfidence["topical"], links[0].Confidence)
+	}
+}
+
+func TestParseLinks_FlatSingle_MissingConfidenceFloored(t *testing.T) {
+	raw := `{"target_id":"019fb992-ea5a-7ef8-aa5c-ed7db94699ca","type":"causal"}`
+	links, _, err := parseLinks(raw)
+	if err != nil || len(links) != 1 {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+	if links[0].Confidence != minRawConfidence["causal"] {
+		t.Fatalf("want per-type floor %.2f, got %.2f", minRawConfidence["causal"], links[0].Confidence)
+	}
+}
+
+func TestParseLinks_FlatSingle_UnusableConfidenceErrors(t *testing.T) {
+	// Present-but-unparseable confidence on the single-link form leaves zero
+	// links — parse error (retry), not a silent zero-link success. Was a
+	// (nil, "", nil) return before the zero-link contract.
+	raw := `{"target_id":"019fb992-ea5a-7ef8-aa5c-ed7db94699ca","type":"topical","confidence":"vibes"}`
+	if _, _, err := parseLinks(raw); err == nil {
+		t.Fatal("unusable confidence on flat single link must be a parse error")
+	}
+}
+
+func TestParseLinks_Array_AllUnusableErrors(t *testing.T) {
+	// Same contract on the canonical array form: entries exist but none is
+	// usable (unknown type + no confidence, or unparseable confidence).
+	raw := `[{"target_id":"019fb992-ea5a-7ef8-aa5c-ed7db94699ca","type":"topical","confidence":"vibes"}]`
+	if _, _, err := parseLinks(raw); err == nil {
+		t.Fatal("array with only unusable entries must be a parse error")
+	}
+}
+
+func TestParseLinks_Array_MissingConfidenceFloored(t *testing.T) {
+	raw := `[{"target_id":"019fb992-ea5a-7ef8-aa5c-ed7db94699ca","type":"supersedes"}]`
+	links, _, err := parseLinks(raw)
+	if err != nil || len(links) != 1 {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+	if links[0].Confidence != minRawConfidence["supersedes"] {
+		t.Fatalf("want per-type floor %.2f, got %.2f", minRawConfidence["supersedes"], links[0].Confidence)
 	}
 }
 

--- a/go/internal/dream/dream_test.go
+++ b/go/internal/dream/dream_test.go
@@ -346,8 +346,8 @@ func TestParseLinks_StringMap_Basic(t *testing.T) {
 	if len(links) != 2 {
 		t.Fatalf("want 2 links, got %d", len(links))
 	}
-	if format != formatObject {
-		t.Errorf("want format %q, got %q", formatObject, format)
+	if format != formatStringMap {
+		t.Errorf("want format %q, got %q", formatStringMap, format)
 	}
 	seen := map[string]string{}
 	for _, l := range links {
@@ -409,8 +409,8 @@ func TestParseLinks_StringMap_Fenced(t *testing.T) {
 	if err != nil || len(links) != 1 || links[0].TargetID != "019fb992-ea5a-7ef8-aa5c-ed7db94699ca" {
 		t.Fatalf("err=%v links=%+v", err, links)
 	}
-	if format != formatFencedObject {
-		t.Errorf("want format %q, got %q", formatFencedObject, format)
+	if format != formatFencedStringMap {
+		t.Errorf("want format %q, got %q", formatFencedStringMap, format)
 	}
 }
 

--- a/go/internal/dream/dream_test.go
+++ b/go/internal/dream/dream_test.go
@@ -331,8 +331,11 @@ func TestParseLinks_ObjectForm_DeterministicOrder(t *testing.T) {
 //
 // Drift form 3: the model collapses the array-of-objects into a terse
 // {"<uuid>": "<type>"} map with NO confidence field. The parser must recover
-// the relationship the model committed to (the type name) and assign the gate
-// floor 0.7 — not invent a "high" 0.9 the model never produced.
+// the relationship the model committed to (the type name) and assign the
+// per-type minRawConfidence floor — not invent a "high" 0.9 the model never
+// produced. Because ANY flat string→string object matches this shape, entries
+// are discriminated (uuid key + known relationship value); prose/status
+// envelopes must remain parse errors (transient retry, not inert cooldown).
 
 func TestParseLinks_StringMap_Basic(t *testing.T) {
 	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"topical","019fb98f-cad3-7bbe-b3be-ccf74d5ba05f":"factual"}`
@@ -360,25 +363,31 @@ func TestParseLinks_StringMap_Basic(t *testing.T) {
 }
 
 func TestParseLinks_StringMap_DeterministicOrder(t *testing.T) {
-	raw := `{"c-3":"topical","a-1":"causal","b-2":"factual"}`
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699cc":"topical","019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"causal","019fb992-ea5a-7ef8-aa5c-ed7db94699cb":"factual"}`
 	for i := 0; i < 20; i++ {
 		links, _, err := parseLinks(raw)
 		if err != nil || len(links) != 3 {
 			t.Fatalf("iter %d: err=%v len=%d", i, err, len(links))
 		}
-		if links[0].TargetID != "a-1" || links[1].TargetID != "b-2" || links[2].TargetID != "c-3" {
+		if links[0].TargetID != "019fb992-ea5a-7ef8-aa5c-ed7db94699ca" ||
+			links[1].TargetID != "019fb992-ea5a-7ef8-aa5c-ed7db94699cb" ||
+			links[2].TargetID != "019fb992-ea5a-7ef8-aa5c-ed7db94699cc" {
 			t.Fatalf("iter %d: order not lex-sorted: %+v", i, links)
+		}
+		// Key→value pairing must survive the sort, not just the ordering.
+		if links[0].Relationship != "causal" || links[1].Relationship != "factual" || links[2].Relationship != "topical" {
+			t.Fatalf("iter %d: key→value pairing broken: %+v", i, links)
 		}
 	}
 }
 
 func TestParseLinks_StringMap_EmptyValueDropped(t *testing.T) {
-	raw := `{"a":"topical","b":"   ","c":""}`
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"topical","019fb992-ea5a-7ef8-aa5c-ed7db94699cb":"   ","019fb992-ea5a-7ef8-aa5c-ed7db94699cc":""}`
 	links, _, err := parseLinks(raw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(links) != 1 || links[0].TargetID != "a" {
+	if len(links) != 1 || links[0].TargetID != "019fb992-ea5a-7ef8-aa5c-ed7db94699ca" {
 		t.Fatalf("blank relationship values must be dropped, got %+v", links)
 	}
 }
@@ -387,7 +396,7 @@ func TestParseLinks_StringMap_AllEmptyErrors(t *testing.T) {
 	// A map whose values are all blank yields zero links; that must surface as
 	// a parse error (transient retry) rather than a silent "no links" success
 	// that would book a multi-day dream cooldown on the block.
-	raw := `{"a":"","b":"  "}`
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"","019fb992-ea5a-7ef8-aa5c-ed7db94699cb":"  "}`
 	_, _, err := parseLinks(raw)
 	if err == nil {
 		t.Error("expected error when all string-map values are blank")
@@ -395,13 +404,95 @@ func TestParseLinks_StringMap_AllEmptyErrors(t *testing.T) {
 }
 
 func TestParseLinks_StringMap_Fenced(t *testing.T) {
-	raw := "```json\n{\"id-1\":\"supersedes\"}\n```"
+	raw := "```json\n{\"019fb992-ea5a-7ef8-aa5c-ed7db94699ca\":\"supersedes\"}\n```"
 	links, format, err := parseLinks(raw)
-	if err != nil || len(links) != 1 || links[0].TargetID != "id-1" {
+	if err != nil || len(links) != 1 || links[0].TargetID != "019fb992-ea5a-7ef8-aa5c-ed7db94699ca" {
 		t.Fatalf("err=%v links=%+v", err, links)
 	}
 	if format != formatFencedObject {
 		t.Errorf("want format %q, got %q", formatFencedObject, format)
+	}
+}
+
+func TestParseLinks_StringMap_ProseEnvelopeStaysError(t *testing.T) {
+	// The critical boundary of this drift form: ANY flat string→string object
+	// unmarshals into map[string]string, including prose/status envelopes.
+	// Those carried a parse error (transient ~5-min retry) before this form
+	// existed; they must KEEP erroring — a pseudo-link parse would be filtered
+	// by filterValidCandidates into a zero-link success and book the multi-day
+	// inert cooldown instead (observed classes: reasoning envelopes, status
+	// envelopes, stringified arrays).
+	for _, raw := range []string{
+		`{"reasoning":"the blocks are unrelated","conclusion":"no links"}`,
+		`{"analysis":"I found no relationships between the source and the candidates."}`,
+		`{"status":"ok","links":"none"}`,
+		`{"relationships":"none"}`,
+		`{"result":"no relationships found"}`,
+		`{"relationships":"[{\"target_id\":\"019fb992-ea5a-7ef8-aa5c-ed7db94699ca\"}]"}`,
+	} {
+		if _, _, err := parseLinks(raw); err == nil {
+			t.Errorf("prose envelope must stay a parse error, got success for %s", raw)
+		}
+	}
+}
+
+func TestParseLinks_StringMap_UnknownRelationshipErrors(t *testing.T) {
+	// A uuid key with an unknown relationship value is indistinguishable from
+	// prose; with no qualifying entry left the map must decline to the parse
+	// error (retry may yield the canonical array with a known type).
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"related"}`
+	if _, _, err := parseLinks(raw); err == nil {
+		t.Error("unknown relationship value must not produce a link")
+	}
+}
+
+func TestParseLinks_StringMap_MixedProseEntriesIgnored(t *testing.T) {
+	// Commentary keys next to a valid uuid→type entry are dropped, the valid
+	// entry survives — mirrors the wrapped form skipping sibling prose fields.
+	raw := `{"note":"weak but real","019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"topical"}`
+	links, _, err := parseLinks(raw)
+	if err != nil || len(links) != 1 {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+	if links[0].TargetID != "019fb992-ea5a-7ef8-aa5c-ed7db94699ca" || links[0].Relationship != "topical" {
+		t.Fatalf("valid entry lost among prose keys: %+v", links[0])
+	}
+}
+
+func TestParseLinks_StringMap_CaseAndWhitespaceNormalised(t *testing.T) {
+	// deepseek drift includes cased type names and cased UUIDs; both are
+	// normalised so the entry clears filterValidCandidates unchanged.
+	raw := `{"019FB992-EA5A-7EF8-AA5C-ED7DB94699CA":" Topical "}`
+	links, _, err := parseLinks(raw)
+	if err != nil || len(links) != 1 {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+	if links[0].TargetID != "019fb992-ea5a-7ef8-aa5c-ed7db94699ca" || links[0].Relationship != "topical" {
+		t.Fatalf("case/whitespace not normalised: %+v", links[0])
+	}
+}
+
+func TestParseLinks_StringMap_PerTypeFloor(t *testing.T) {
+	// The assigned confidence is the per-type minRawConfidence floor, not a
+	// hardcoded 0.7 — 'recurrent' has floor 0.8 and would be silently dropped
+	// by filterValidCandidates at 0.7.
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"recurrent"}`
+	links, _, err := parseLinks(raw)
+	if err != nil || len(links) != 1 {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+	if links[0].Confidence != minRawConfidence["recurrent"] {
+		t.Fatalf("want per-type floor %.2f, got %.2f", minRawConfidence["recurrent"], links[0].Confidence)
+	}
+}
+
+func TestParseLinks_StringMap_FlatSingleShapeStaysError(t *testing.T) {
+	// {"target_id": "<uuid>", "type": ""} misses the flat-single form (empty
+	// type) and is all-strings — without key discrimination it would parse as
+	// a garbage link with TargetID "target_id".
+	raw := `{"target_id":"019fb992-ea5a-7ef8-aa5c-ed7db94699ca","type":""}`
+	if _, _, err := parseLinks(raw); err == nil {
+		t.Error("degenerate flat-single shape must stay a parse error")
 	}
 }
 

--- a/go/internal/dream/dream_test.go
+++ b/go/internal/dream/dream_test.go
@@ -327,6 +327,84 @@ func TestParseLinks_ObjectForm_DeterministicOrder(t *testing.T) {
 	}
 }
 
+// --- parseLinks String-Map Drift Tests (deepseek-v4-flash, 2026-08-01) ---.
+//
+// Drift form 3: the model collapses the array-of-objects into a terse
+// {"<uuid>": "<type>"} map with NO confidence field. The parser must recover
+// the relationship the model committed to (the type name) and assign the gate
+// floor 0.7 — not invent a "high" 0.9 the model never produced.
+
+func TestParseLinks_StringMap_Basic(t *testing.T) {
+	raw := `{"019fb992-ea5a-7ef8-aa5c-ed7db94699ca":"topical","019fb98f-cad3-7bbe-b3be-ccf74d5ba05f":"factual"}`
+	links, format, err := parseLinks(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(links) != 2 {
+		t.Fatalf("want 2 links, got %d", len(links))
+	}
+	if format != formatObject {
+		t.Errorf("want format %q, got %q", formatObject, format)
+	}
+	seen := map[string]string{}
+	for _, l := range links {
+		seen[l.TargetID] = l.Relationship
+		if l.Confidence != 0.7 {
+			t.Errorf("%s: confidence must be gate floor 0.7 (model gave none), got %.2f", l.TargetID, l.Confidence)
+		}
+	}
+	if seen["019fb992-ea5a-7ef8-aa5c-ed7db94699ca"] != "topical" ||
+		seen["019fb98f-cad3-7bbe-b3be-ccf74d5ba05f"] != "factual" {
+		t.Errorf("relationship types lost: %v", seen)
+	}
+}
+
+func TestParseLinks_StringMap_DeterministicOrder(t *testing.T) {
+	raw := `{"c-3":"topical","a-1":"causal","b-2":"factual"}`
+	for i := 0; i < 20; i++ {
+		links, _, err := parseLinks(raw)
+		if err != nil || len(links) != 3 {
+			t.Fatalf("iter %d: err=%v len=%d", i, err, len(links))
+		}
+		if links[0].TargetID != "a-1" || links[1].TargetID != "b-2" || links[2].TargetID != "c-3" {
+			t.Fatalf("iter %d: order not lex-sorted: %+v", i, links)
+		}
+	}
+}
+
+func TestParseLinks_StringMap_EmptyValueDropped(t *testing.T) {
+	raw := `{"a":"topical","b":"   ","c":""}`
+	links, _, err := parseLinks(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(links) != 1 || links[0].TargetID != "a" {
+		t.Fatalf("blank relationship values must be dropped, got %+v", links)
+	}
+}
+
+func TestParseLinks_StringMap_AllEmptyErrors(t *testing.T) {
+	// A map whose values are all blank yields zero links; that must surface as
+	// a parse error (transient retry) rather than a silent "no links" success
+	// that would book a multi-day dream cooldown on the block.
+	raw := `{"a":"","b":"  "}`
+	_, _, err := parseLinks(raw)
+	if err == nil {
+		t.Error("expected error when all string-map values are blank")
+	}
+}
+
+func TestParseLinks_StringMap_Fenced(t *testing.T) {
+	raw := "```json\n{\"id-1\":\"supersedes\"}\n```"
+	links, format, err := parseLinks(raw)
+	if err != nil || len(links) != 1 || links[0].TargetID != "id-1" {
+		t.Fatalf("err=%v links=%+v", err, links)
+	}
+	if format != formatFencedObject {
+		t.Errorf("want format %q, got %q", formatFencedObject, format)
+	}
+}
+
 func TestParseLinks_CodeFenceArray(t *testing.T) {
 	raw := "```json\n[{\"target_id\":\"id-1\",\"type\":\"factual\",\"confidence\":0.9}]\n```"
 	links, _, err := parseLinks(raw)

--- a/go/internal/dream/evaluate.go
+++ b/go/internal/dream/evaluate.go
@@ -139,16 +139,17 @@ func EvaluateRelationships(ctx context.Context, pool *pgxpool.Pool, r *Router, o
 		return nil, fmt.Errorf("dream: parse links: %w", err)
 	}
 
-	// Welle 46 (2026-05-22): post-parse hard-constraint on supersedes direction.
-	// Drops links where source is not strictly newer than target. Runs before
-	// filterValidCandidates so a dropped supersedes does not occupy a cap slot.
-	preDirCount := len(links)
-	links = enforceSupersedesDirection(links, source.CreatedAt, candidates)
-	if dropped := preDirCount - len(links); dropped > 0 {
+	// Welle 46 (2026-05-22): post-parse hard-constraint on supersedes
+	// direction. Downgrades inverted supersedes links to topical. The old
+	// len-diff telemetry here was structurally dead (downgrade never changes
+	// the count) — the function now reports the downgrade count itself.
+	var dirDowngraded int
+	links, dirDowngraded = enforceSupersedesDirection(links, source.CreatedAt, candidates)
+	if dirDowngraded > 0 {
 		if entry.Metadata == nil {
 			entry.Metadata = map[string]any{}
 		}
-		entry.Metadata["supersedes_direction_dropped"] = dropped
+		entry.Metadata["supersedes_direction_downgraded"] = dirDowngraded
 	}
 
 	candidateIDs := make(map[string]bool)

--- a/go/internal/dream/linkfilters.go
+++ b/go/internal/dream/linkfilters.go
@@ -198,8 +198,11 @@ func acceptSupersedes(srcCat, tgtCat string, srcCreated, tgtCreated time.Time, t
 // the edge in the graph at the conservative cost of one relationship class:
 // 'topical' is the documented fallback per V5 prompt ("when in doubt: topical")
 // and matches what coerceCategoryFactual does for same-category factual links.
-// Audit-Trail: entry.Metadata["supersedes_direction_downgraded"] is set by
-// the caller (evaluate.go) so the rate of inversion stays observable.
+// Audit-Trail: the returned downgrade count feeds
+// entry.Metadata["supersedes_direction_downgraded"] in the caller
+// (evaluate.go) so the rate of inversion stays observable. (The caller
+// previously measured len(in)-len(out), which is structurally zero since the
+// Welle-46 switch from drop to downgrade — the telemetry was dead.)
 //
 // candidates[].UpdatedAt is used as approximation for CreatedAt because the
 // rrf.SearchResult struct only carries UpdatedAt. For the Dream corpus,
@@ -207,14 +210,15 @@ func acceptSupersedes(srcCat, tgtCat string, srcCreated, tgtCreated time.Time, t
 // CreatedAt (exception: blocks updated after creation can flip the inequality;
 // rare and conservative). The final created_at check in acceptSupersedes
 // (writelinks.go) is the authoritative gate — this is defense in depth.
-func enforceSupersedesDirection(links []Link, sourceCreated time.Time, candidates []BlockInfo) []Link {
+func enforceSupersedesDirection(links []Link, sourceCreated time.Time, candidates []BlockInfo) ([]Link, int) {
 	if len(links) == 0 {
-		return links
+		return links, 0
 	}
 	candByID := make(map[string]time.Time, len(candidates))
 	for _, c := range candidates {
 		candByID[c.ID] = c.UpdatedAt
 	}
+	downgraded := 0
 	out := make([]Link, 0, len(links))
 	for _, l := range links {
 		if l.Relationship == "supersedes" {
@@ -234,11 +238,12 @@ func enforceSupersedesDirection(links []Link, sourceCreated time.Time, candidate
 					"target_updated", tgtTS,
 				)
 				l.Relationship = "topical"
+				downgraded++
 			}
 		}
 		out = append(out, l)
 	}
-	return out
+	return out, downgraded
 }
 
 // V9 check: causal requires source predates target by created_at.

--- a/go/internal/dream/parse.go
+++ b/go/internal/dream/parse.go
@@ -11,12 +11,14 @@ import (
 // to track LLM drift patterns over time. Empty string means "no parseable shape"
 // (parse error or empty/sentinel input — distinguishable via the returned error).
 const (
-	formatArray         = "array"
-	formatObject        = "object"
-	formatFencedArray   = "fenced-array"
-	formatFencedObject  = "fenced-object"
-	formatWrapped       = "wrapped"
-	formatFencedWrapped = "fenced-wrapped"
+	formatArray           = "array"
+	formatObject          = "object"
+	formatFencedArray     = "fenced-array"
+	formatFencedObject    = "fenced-object"
+	formatWrapped         = "wrapped"
+	formatFencedWrapped   = "fenced-wrapped"
+	formatStringMap       = "string-map"
+	formatFencedStringMap = "fenced-string-map"
 )
 
 // parseLinks parses the LLM JSON response into Link structs.
@@ -24,6 +26,7 @@ const (
 //   - Named-wrapper form (cloud relays, PR #11 review): {"<key>": [ <links> ], ...}
 //   - Single flat object form (Welle 49): {"target_id": "...", "type": ..., ...}
 //   - Object-map form (audit S25, 2026-05-03): {"<uuid>": {"type": "...", "confidence": <float|string>}, ...}
+//   - String-map form (deepseek-v4-flash, PR #12): {"<uuid>": "<type>", ...} — no confidence field
 //   - String-encoded confidence labels: "high"|"medium"|"low" → 0.9/0.6/0.3
 //
 // Strips a leading ```json fence if present (43/1481 historical cases). The fence
@@ -31,7 +34,7 @@ const (
 // in the returned format token.
 //
 // Returns (links, format, err). format is one of formatArray | formatObject |
-// formatWrapped | formatFencedArray | formatFencedObject | formatFencedWrapped;
+// formatWrapped | formatStringMap or their fenced-* variants;
 // empty for empty/sentinel inputs and for parse errors. Map→slice conversion
 // sorts by TargetID for deterministic downstream behavior.
 func parseLinks(raw string) ([]Link, string, error) {
@@ -118,15 +121,18 @@ func parseLinks(raw string) ([]Link, string, error) {
 			return out, formatObject, nil
 		}
 
-		// Drift form 3 — see parseStringMapLinks.
+		// Drift form 3 — see parseStringMapLinks. Distinct format token: the
+		// whole point of parse_format telemetry is tracking WHICH drift form a
+		// model emits; reusing formatObject (already shared by forms 1 and 2)
+		// would make this form invisible in the drift log.
 		if links, ok := parseStringMapLinks(body); ok {
 			if len(links) == 0 {
 				return nil, "", fmt.Errorf("parse links: string map has no uuid→relationship entries (prose or degenerate object): %w", arrErr)
 			}
 			if wasFenced {
-				return links, formatFencedObject, nil
+				return links, formatFencedStringMap, nil
 			}
-			return links, formatObject, nil
+			return links, formatStringMap, nil
 		}
 	}
 

--- a/go/internal/dream/parse.go
+++ b/go/internal/dream/parse.go
@@ -54,11 +54,18 @@ func parseLinks(raw string) ([]Link, string, error) {
 	if arrErr == nil {
 		out := make([]Link, 0, len(rawArr))
 		for _, r := range rawArr {
-			conf, ok := coerceConfidence(r.Confidence)
+			conf, ok := confidenceOrFloor(r.Confidence, r.Type)
 			if !ok {
 				continue
 			}
 			out = append(out, Link{TargetID: r.TargetID, Relationship: r.Type, Confidence: conf})
+		}
+		// Zero-link contract: a non-empty structure that yields no usable link
+		// is degenerate output, not a "nothing to link" verdict — surface it as
+		// a parse error (transient retry) instead of a success that books the
+		// multi-day inert cooldown. The empty-array sentinel returned early.
+		if len(rawArr) > 0 && len(out) == 0 {
+			return nil, "", fmt.Errorf("parse links: %d array entries, none usable", len(rawArr))
 		}
 		if wasFenced {
 			return out, formatFencedArray, nil
@@ -88,37 +95,29 @@ func parseLinks(raw string) ([]Link, string, error) {
 			Confidence json.RawMessage `json:"confidence"`
 		}
 		if err := json.Unmarshal([]byte(body), &single); err == nil && single.TargetID != "" && single.Type != "" {
-			conf, ok := coerceConfidence(single.Confidence)
+			conf, ok := confidenceOrFloor(single.Confidence, single.Type)
 			if !ok {
-				return nil, "", nil
+				// Zero-link contract (see array branch): the model named a link
+				// but its confidence is unusable — error (retry), not a silent
+				// zero-link success that books the inert cooldown.
+				return nil, "", fmt.Errorf("parse links: flat single link with unusable confidence: %w", arrErr)
 			}
 			return []Link{{TargetID: single.TargetID, Relationship: single.Type, Confidence: conf}}, formatObject, nil
 		}
 
-		// Drift form 2 (Welle-25, qwen3.6:27b ollama): wrapper-map with IDs as keys.
-		var obj map[string]struct {
-			Type       string          `json:"type"`
-			Confidence json.RawMessage `json:"confidence"`
-		}
-		if err := json.Unmarshal([]byte(body), &obj); err == nil {
-			ids := make([]string, 0, len(obj))
-			for id := range obj {
-				ids = append(ids, id)
-			}
-			sort.Strings(ids)
-			out := make([]Link, 0, len(obj))
-			for _, id := range ids {
-				v := obj[id]
-				conf, ok := coerceConfidence(v.Confidence)
-				if !ok {
-					continue
-				}
-				out = append(out, Link{TargetID: id, Relationship: v.Type, Confidence: conf})
+		// Drift form 2 (Welle-25, qwen3.6:27b ollama): wrapper-map with IDs as
+		// keys — see parseObjectMapLinks.
+		if links, degenerate, ok := parseObjectMapLinks(body); ok {
+			// Zero-link contract (see array branch): covers {"<uuid>": null}
+			// and maps whose every entry lost its confidence — error (retry),
+			// not inert cooldown. The empty-object sentinel returned early.
+			if degenerate {
+				return nil, "", fmt.Errorf("parse links: object map entries present, none usable: %w", arrErr)
 			}
 			if wasFenced {
-				return out, formatFencedObject, nil
+				return links, formatFencedObject, nil
 			}
-			return out, formatObject, nil
+			return links, formatObject, nil
 		}
 
 		// Drift form 3 — see parseStringMapLinks. Distinct format token: the
@@ -249,6 +248,55 @@ func stripCodeFence(raw string) string {
 	raw = strings.TrimPrefix(raw, "```")
 	raw = strings.TrimSuffix(raw, "```")
 	return strings.TrimSpace(raw)
+}
+
+// parseObjectMapLinks handles drift form 2 (Welle-25, qwen3.6:27b ollama):
+// wrapper-map with IDs as keys and {type, confidence} struct values.
+// Returns ok=false when body is not such a map; degenerate=true when it IS
+// one with entries but none was usable (the caller surfaces that as a parse
+// error under the zero-link contract). Map→slice conversion sorts by
+// TargetID for deterministic downstream behavior.
+func parseObjectMapLinks(body string) (links []Link, degenerate, ok bool) {
+	var obj map[string]struct {
+		Type       string          `json:"type"`
+		Confidence json.RawMessage `json:"confidence"`
+	}
+	if err := json.Unmarshal([]byte(body), &obj); err != nil {
+		return nil, false, false
+	}
+	ids := make([]string, 0, len(obj))
+	for id := range obj {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]Link, 0, len(obj))
+	for _, id := range ids {
+		v := obj[id]
+		conf, confOK := confidenceOrFloor(v.Confidence, v.Type)
+		if !confOK {
+			continue
+		}
+		out = append(out, Link{TargetID: id, Relationship: v.Type, Confidence: conf})
+	}
+	return out, len(obj) > 0 && len(out) == 0, true
+}
+
+// confidenceOrFloor resolves an entry's confidence. A present value goes
+// through coerceConfidence unchanged. An ABSENT one (missing key or JSON
+// null) falls back to the per-type minRawConfidence floor when the type
+// names a known relationship — the model committed to a relationship but
+// gave no strength signal, the same doctrine the string-map form applies
+// (PR #12). Present-but-unparseable values stay dropped (the model DID emit
+// a strength signal, it is just unreadable — retry may fix it), and absent
+// values with an unknown type cannot be floored.
+func confidenceOrFloor(raw json.RawMessage, rel string) (float64, bool) {
+	if len(raw) == 0 || string(raw) == "null" {
+		if validRelationships[rel] {
+			return minRawConfidence[rel], true
+		}
+		return 0, false
+	}
+	return coerceConfidence(raw)
 }
 
 // coerceConfidence accepts a json.RawMessage and returns a float64 confidence.

--- a/go/internal/dream/parse.go
+++ b/go/internal/dream/parse.go
@@ -118,45 +118,70 @@ func parseLinks(raw string) ([]Link, string, error) {
 			return out, formatObject, nil
 		}
 
-		// Drift form 3 (deepseek-v4-flash via opencode.ai, 2026-08-01): compact
-		// string-map with IDs as keys and the relationship type as a bare string
-		// value, no confidence field — {"<uuid>": "topical", ...}. The model emits
-		// this when it collapses the array-of-objects into a terse id→type map.
-		// Confidence is ABSENT: the model named a relationship type but gave no
-		// strength signal. We must not invent one (assigning "high"/0.9 would be
-		// self-reported confidence the model never produced). Assign the gate
-		// floor 0.7 instead — the lowest honest value that still lets the link
-		// through the per-type minRawConfidence gate, preserving the relationship
-		// the model DID commit to (the type name) while flagging it as unweighted.
-		// Downstream weighting treats 0.7 as the weakest surviving link. Tried
-		// after the object-map form, whose struct-valued unmarshal fails on the
-		// bare-string values and falls through to here.
-		var strMap map[string]string
-		if err := json.Unmarshal([]byte(body), &strMap); err == nil {
-			ids := make([]string, 0, len(strMap))
-			for id := range strMap {
-				ids = append(ids, id)
-			}
-			sort.Strings(ids)
-			out := make([]Link, 0, len(strMap))
-			for _, id := range ids {
-				rel := strings.TrimSpace(strMap[id])
-				if rel == "" {
-					continue
-				}
-				out = append(out, Link{TargetID: id, Relationship: rel, Confidence: 0.7})
-			}
-			if len(out) == 0 {
-				return nil, "", fmt.Errorf("parse links: %w", arrErr)
+		// Drift form 3 — see parseStringMapLinks.
+		if links, ok := parseStringMapLinks(body); ok {
+			if len(links) == 0 {
+				return nil, "", fmt.Errorf("parse links: string map has no uuid→relationship entries (prose or degenerate object): %w", arrErr)
 			}
 			if wasFenced {
-				return out, formatFencedObject, nil
+				return links, formatFencedObject, nil
 			}
-			return out, formatObject, nil
+			return links, formatObject, nil
 		}
 	}
 
 	return nil, "", fmt.Errorf("parse links: %w", arrErr)
+}
+
+// parseStringMapLinks handles drift form 3 (deepseek-v4-flash via opencode.ai,
+// 2026-08-01): compact string-map with IDs as keys and the relationship type
+// as a bare string value, no confidence field — {"<uuid>": "topical", ...}.
+// The model emits this when it collapses the array-of-objects into a terse
+// id→type map. Tried after the object-map form, whose struct-valued unmarshal
+// fails on the bare-string values and falls through to here.
+//
+// This shape is maximally ambiguous: ANY flat string→string object matches
+// map[string]string, including prose/status envelopes like
+// {"reasoning": "the blocks are unrelated"} that MUST stay parse errors
+// (transient retry) — accepting them as pseudo-links would read downstream as
+// "nothing to link" and book the multi-day inert cooldown the
+// parseWrappedLinks constraints exist to prevent. So unlike the other drift
+// forms, entries are discriminated HERE: the key must look like a block UUID
+// and the value must name a known relationship type (both case-normalised so
+// the entry clears filterValidCandidates unchanged). Returns ok=false when
+// body is not a flat string map at all; ok=true with an empty slice when it
+// is one but no entry qualifies — the caller turns that into the hard parse
+// error (this is not a link map).
+//
+// Confidence is ABSENT: the model named a relationship type but gave no
+// strength signal. We must not invent one (assigning "high"/0.9 would be
+// self-reported confidence the model never produced). Assign the per-type
+// minRawConfidence floor — the lowest honest value that still clears the
+// dream write gate for that type (0.7; 'recurrent' 0.8). Note this floor sits
+// BELOW the RRF graph-expansion retrieval gate (graph.min_confidence, default
+// 0.75): floored links are persisted and visible in the ego graph, but stay
+// out of RRF expansion until a later dream cycle re-classifies them with a
+// real confidence signal.
+func parseStringMapLinks(body string) ([]Link, bool) {
+	var strMap map[string]string
+	if err := json.Unmarshal([]byte(body), &strMap); err != nil {
+		return nil, false
+	}
+	ids := make([]string, 0, len(strMap))
+	for id := range strMap {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]Link, 0, len(strMap))
+	for _, rawID := range ids {
+		id := strings.ToLower(strings.TrimSpace(rawID))
+		rel := strings.ToLower(strings.TrimSpace(strMap[rawID]))
+		if !uuidPattern.MatchString(id) || !validRelationships[rel] {
+			continue
+		}
+		out = append(out, Link{TargetID: id, Relationship: rel, Confidence: minRawConfidence[rel]})
+	}
+	return out, true
 }
 
 // parseWrappedLinks handles drift form 0 (cloud relays via response_format

--- a/go/internal/dream/parse.go
+++ b/go/internal/dream/parse.go
@@ -117,6 +117,43 @@ func parseLinks(raw string) ([]Link, string, error) {
 			}
 			return out, formatObject, nil
 		}
+
+		// Drift form 3 (deepseek-v4-flash via opencode.ai, 2026-08-01): compact
+		// string-map with IDs as keys and the relationship type as a bare string
+		// value, no confidence field — {"<uuid>": "topical", ...}. The model emits
+		// this when it collapses the array-of-objects into a terse id→type map.
+		// Confidence is ABSENT: the model named a relationship type but gave no
+		// strength signal. We must not invent one (assigning "high"/0.9 would be
+		// self-reported confidence the model never produced). Assign the gate
+		// floor 0.7 instead — the lowest honest value that still lets the link
+		// through the per-type minRawConfidence gate, preserving the relationship
+		// the model DID commit to (the type name) while flagging it as unweighted.
+		// Downstream weighting treats 0.7 as the weakest surviving link. Tried
+		// after the object-map form, whose struct-valued unmarshal fails on the
+		// bare-string values and falls through to here.
+		var strMap map[string]string
+		if err := json.Unmarshal([]byte(body), &strMap); err == nil {
+			ids := make([]string, 0, len(strMap))
+			for id := range strMap {
+				ids = append(ids, id)
+			}
+			sort.Strings(ids)
+			out := make([]Link, 0, len(strMap))
+			for _, id := range ids {
+				rel := strings.TrimSpace(strMap[id])
+				if rel == "" {
+					continue
+				}
+				out = append(out, Link{TargetID: id, Relationship: rel, Confidence: 0.7})
+			}
+			if len(out) == 0 {
+				return nil, "", fmt.Errorf("parse links: %w", arrErr)
+			}
+			if wasFenced {
+				return out, formatFencedObject, nil
+			}
+			return out, formatObject, nil
+		}
 	}
 
 	return nil, "", fmt.Errorf("parse links: %w", arrErr)


### PR DESCRIPTION
## Problem

`deepseek-v4-flash` (via opencode.ai) sometimes collapses the expected array-of-objects link response into a terse string map with no confidence field:

```json
{
  "019fb992-ea5a-7ef8-aa5c-ed7db94699ca": "topical",
  "019fb98f-cad3-7bbe-b3be-ccf74d5ba05f": "topical"
}
```

None of the existing drift forms handle this shape (array, flat single object, object-map with struct values, named wrapper), so `parseLinks` surfaces:

```
parse links: json: cannot unmarshal object into Go value of type []struct { TargetID string; Type string; Confidence json.RawMessage }
```

and every link in that dream cycle is lost. Observed repeatedly in production logs (the same block sometimes returns the correct array and sometimes this map — the model is nondeterministic about the shape).

## Fix

Add a fifth drift form in `parseLinks`: `map[string]string` keyed by target ID, with the relationship type as the bare string value.

- **Confidence is absent.** The model named a relationship type but gave no strength signal, so we assign the gate floor `0.7` — the lowest honest value that still clears the per-type `minRawConfidence` gate — rather than inventing a `"high"`/`0.9` the model never produced. Downstream weighting treats 0.7 as the weakest surviving link.
- Blank values are dropped.
- An all-blank map surfaces as a parse error (transient retry) instead of a silent zero-link success that would book a multi-day dream cooldown on the block.
- Output is sorted by `TargetID` for deterministic downstream behavior, matching the existing object-map form.

Tried after the struct-valued object-map form, whose `json.Unmarshal` fails on the bare-string values and falls through to here.

## Tests

Five new `TestParseLinks_StringMap_*` cases:
- basic parse of the exact production payload (type recovered, confidence == 0.7)
- deterministic lex-sorted ordering over 20 iterations
- blank/whitespace values dropped
- all-blank map returns an error
- fenced ```json variant

```
go test ./internal/dream/ -run TestParseLinks -v   # all PASS
go vet ./internal/dream/                            # clean
go test ./internal/dream/                           # ok
```