### PR TITLE
fix(dream): zu kurze LLM-Keywords mit Tokenizer auffuellen

### DIFF
--- a/go/internal/dream/keywords.go
+++ b/go/internal/dream/keywords.go
@@ -132,6 +132,19 @@ func GenerateKeywords(ctx context.Context, pool *pgxpool.Pool, r *Router, block 
 				return nil, parseErr
 			}
 			if len(kws) < MinKeywords {
+				// Ornith 1.5 (prod 2026-08-27) liefert oft valide, aber zu
+				// wenige Keywords (2 statt 5-8). Statt den ganzen Versuch zu
+				// verwerfen (3 Retries + Fallback), die LLM-Keywords BEHALTEN
+				// und mit dem deterministischen Tokenizer auffuellen — so geht
+				// kein LLM-Ergebnis verloren und der Block wird trotzdem
+				// verarbeitet. Nur bei 0 LLM-Keywords bleibt es beim Fehler
+				// (Retry-Pfad), da nichts aufzufuellen waere.
+				if len(kws) > 0 {
+					filled := fillKeywords(block.Title, block.Content, kws)
+					if len(filled) >= MinKeywords {
+						return filled, nil
+					}
+				}
 				countErr := fmt.Errorf("dream: keywords too few (%d)", len(kws))
 				entry.Err = countErr
 				return nil, countErr
@@ -164,6 +177,40 @@ func GenerateKeywords(ctx context.Context, pool *pgxpool.Pool, r *Router, block 
 		return nil, fmt.Errorf("dream: keyword generation failed after %d attempts: %w", KeywordsMaxRetries, lastErr)
 	}
 	return fallback, nil
+}
+
+// fillKeywords ergaenzt eine zu kurze LLM-Keyword-Liste mit deterministischen
+// Tokenizer-Keywords (ExtractKeywords) bis MinKeywords — ohne Duplikate und
+// ohne die LLM-Keywords zu verlieren. Die Reihenfolge der LLM-Keywords bleibt
+// erhalten (sie sind semantisch staerker); der Tokenizer fuellt nur auf.
+// Gibt die urspruengliche Liste zurueck, wenn das Auffuellen MinKeywords nicht
+// erreicht (der Caller behandelt das dann als too-few-Fehler).
+func fillKeywords(title, content string, llmKeywords []string) []string {
+	if len(llmKeywords) >= MinKeywords {
+		return llmKeywords
+	}
+	seen := make(map[string]bool, len(llmKeywords)+MaxKeywords)
+	out := make([]string, 0, MinKeywords)
+	for _, k := range llmKeywords {
+		k = strings.TrimSpace(k)
+		if k == "" || seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, k)
+	}
+	// Tokenizer-Keywords als Ergaenzung — stoppt sobald MinKeywords erreicht.
+	for _, k := range ExtractKeywords(title, content, MaxKeywords) {
+		if len(out) >= MinKeywords {
+			break
+		}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, k)
+	}
+	return out
 }
 
 // buildKeywordPrompt wraps the block in the XML-escaped template the prompt expects.

--- a/go/internal/dream/keywords_fill_test.go
+++ b/go/internal/dream/keywords_fill_test.go
@@ -1,0 +1,67 @@
+package dream
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GottZ/ctx/internal/backends"
+	"github.com/GottZ/ctx/internal/llm"
+)
+
+// TestGenerateKeywords_FillsTooFew pins den Ornith-Fix (prod 2026-08-27):
+// wenn das LLM valide, aber zu wenige Keywords liefert (2 statt >= MinKeywords),
+// werden sie mit dem deterministischen Tokenizer aufgefuellt statt den Versuch
+// als Fehler zu verwerfen. Die LLM-Keywords bleiben erhalten.
+func TestGenerateKeywords_FillsTooFew(t *testing.T) {
+	r := newTestRouter()
+	mockChatJSON(t, func(ctx context.Context, _, _, _ string, _ *bool, _, _ string, _ llm.Options, _ time.Duration) (*llm.ChatResponse, error) {
+		// Ornith-Signatur: nur 2 Keywords
+		return constResp(`["Reverse Proxy","Load Balancing"]`)(ctx, "", "", "", nil, "", "", llm.Options{}, 0)
+	})
+
+	blk := srcBlock("00000000-0000-4000-8000-00000000000b")
+	blk.Sensitivity = backends.SensInternal
+	blk.Title = "Reverse Proxy Setup"
+	blk.Content = "Ein Reverse Proxy ist ein Server der als Vermittler zwischen Clients und Backend-Servern fungiert. Er terminiert TLS, verteilt Last und versteckt die Backend-Infrastruktur. Traefik ist unser Reverse Proxy auf INFRA-RP."
+
+	kws, err := GenerateKeywords(context.Background(), nil, r, &blk)
+	if err != nil {
+		t.Fatalf("GenerateKeywords should fill too-few, got error: %v", err)
+	}
+	if len(kws) < MinKeywords {
+		t.Fatalf("keywords = %v, want >= %d (filled)", kws, MinKeywords)
+	}
+	// LLM-Keywords muessen erhalten bleiben
+	found := false
+	for _, k := range kws {
+		if k == "reverse proxy" || k == "Reverse Proxy" || k == "load balancing" || k == "Load Balancing" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("LLM-Keywords gingen verloren: %v", kws)
+	}
+}
+
+// TestFillKeywords_DedupAndFill pinnt fillKeywords direkt: keine Duplikate,
+// LLM-Keywords zuerst, Tokenizer fuellt bis MinKeywords.
+func TestFillKeywords_DedupAndFill(t *testing.T) {
+	llm := []string{"Reverse Proxy", "Traefik"}
+	filled := fillKeywords("Reverse Proxy Setup", "Reverse Proxy Traefik INFRA-RP TLS Backend Load Balancer", llm)
+	if len(filled) < MinKeywords {
+		t.Fatalf("filled = %v, want >= %d", filled, MinKeywords)
+	}
+	seen := map[string]bool{}
+	for _, k := range filled {
+		if seen[k] {
+			t.Fatalf("Duplikat: %q in %v", k, filled)
+		}
+		seen[k] = true
+	}
+	// LLM-Keywords zuerst
+	if filled[0] != "Reverse Proxy" || filled[1] != "Traefik" {
+		t.Errorf("LLM-Keywords nicht zuerst: %v", filled)
+	}
+}


### PR DESCRIPTION
# fix(dream): zu kurze LLM-Keywords mit Tokenizer auffuellen

## Problem (prod-beobachtet 2026-08-27)

Seit dem Einsatz von **Ornith 1.5** als Chat-Backend liefert der LLM-Keyword-Generator
oft valide, aber **zu wenige Keywords** (2 statt 5–8). Folge:

- `dream: keywords too few (2)` → 3 Retries + deterministischer Fallback
- Der gesamte LLM-Versuch wird verworfen, Block wird geparkt → Keyword-Generation
  lief vor dem Patch zu **94,6 %** in den `too few`-Pfad (35 von 37 Calls in 6h),
  Erfolgsquote nur **2,7 %**.

Bisherige Logik verwarf bei `too few` das komplette LLM-Ergebnis und griff auf den
(roheren) deterministischen Extraktor zurück — dabei waren die gelieferten Keywords
inhaltlich brauchbar, nur die Anzahl unterschritt `MinKeywords` (3).

## Fix

In `internal/dream/keywords.go` neu: `fillKeywords()`.

- **LLM-Keywords werden behalten** (nicht verworfen) und in Original-Reihenfolge übernommen.
- Fehlende Keywords bis `MinKeywords` werden **deterministisch** über den bestehenden
  `ExtractKeywords`-Tokenizer aufgefüllt (ohne Duplikate, LLM-Reihenfolge zuerst).
- Nur bei **0** LLM-Keywords bleibt es beim bisherigen Retry-Pfad.

Damit geht kein LLM-Ergebnis verloren, der Block wird trotzdem verarbeitet und die
Keywords bleiben deterministisch (kein Drift zwischen Runs).

## Tests

- `TestGenerateKeywords_FillsTooFew`: 2 LLM-Keywords → auf `MinKeywords` gefüllt
- `TestFillKeywords_DedupAndFill`: keine Duplikate, Reihenfolge LLM-Keywords zuerst
- Alle bestehenden Keyword-Tests (Fallback, Object-Drift, Determinismus, Cap) weiter grün

## Prod-Evidenz (6h vor vs. 6h nach Deploy 2026-08-27)

| Metrik | PRE | POST |
|---|---|---|
| `dream-keywords` Calls gesamt | 37 | 11 |
| Erfolg (error NULL) | **1 (2,7 %)** | **11 (100 %)** |
| `too few`-Fehler | **35 (94,6 %)** | **0 (0 %)** |
| eval-Erfolg | 95,8 % | **97,2 %** |
| Embed-Folge-Calls | 53 | 80 |

Kein Regressions-Signal, Health ok, 0 Generation-Failures. Detaillierter Report im
zugehörigen Beobachtungs-Cron.
