### PR TITLE
fix(dream): zu kurze LLM-Keywords mit deterministischem Tokenizer auffuellen

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -163,7 +163,15 @@ else's environment — that led to a fix landing in the repository.
   path-splitting tokenizer and an object-drift keyword parse — hardened
   with a deterministic, capped drift salvage, a synthetic-fixture test and
   a truthful park log, plus a web editor for per-row `model_map` params
-  the passthrough made meaningful.
+  the passthrough made meaningful. Also PR
+  [#42](https://github.com/GottZ/ctx/pull/42): a sparse model (Ornith 1.5
+  returning 2 keywords where 5-8 were asked) hit the "too few" path on most
+  blocks, burning the retries and then replacing its valid keywords with a
+  tokenizer-only list; the shipped fix keeps his idea of topping the LLM
+  keywords up with the deterministic tokenizer, hardened to run after the
+  retries instead of short-circuiting them, to fill up to `MaxKeywords`, and
+  to deduplicate case-insensitively and against the tokens of multi-word
+  keywords, with mutation-tested pins for each rule.
 
 ## How to be listed
 

--- a/go/internal/dream/keywords.go
+++ b/go/internal/dream/keywords.go
@@ -91,6 +91,9 @@ func GenerateKeywords(ctx context.Context, pool *pgxpool.Pool, r *Router, block 
 	opts := keywordOptions()
 
 	var lastErr error
+	// Longest valid-but-short keyword list seen across the attempts; feeds
+	// the deterministic fill once the retries are exhausted.
+	var bestShort []string
 	for attempt := 1; attempt <= KeywordsMaxRetries; attempt++ {
 		// Honour parent cancellation between retries.
 		if ctx.Err() != nil {
@@ -132,18 +135,14 @@ func GenerateKeywords(ctx context.Context, pool *pgxpool.Pool, r *Router, block 
 				return nil, parseErr
 			}
 			if len(kws) < MinKeywords {
-				// Ornith 1.5 (prod 2026-08-27) liefert oft valide, aber zu
-				// wenige Keywords (2 statt 5-8). Statt den ganzen Versuch zu
-				// verwerfen (3 Retries + Fallback), die LLM-Keywords BEHALTEN
-				// und mit dem deterministischen Tokenizer auffuellen — so geht
-				// kein LLM-Ergebnis verloren und der Block wird trotzdem
-				// verarbeitet. Nur bei 0 LLM-Keywords bleibt es beim Fehler
-				// (Retry-Pfad), da nichts aufzufuellen waere.
-				if len(kws) > 0 {
-					filled := fillKeywords(block.Title, block.Content, kws)
-					if len(filled) >= MinKeywords {
-						return filled, nil
-					}
+				// Too few is still an attempt failure (the llmlog row keeps
+				// the "too few" signal, and a sparse model gets its retries),
+				// but the valid keywords are remembered: if every attempt
+				// comes back short they seed the deterministic fill below
+				// instead of being thrown away (PR #42, Ornith 1.5 returning
+				// 2 keywords where 5-8 were asked).
+				if len(kws) > len(bestShort) {
+					bestShort = kws
 				}
 				countErr := fmt.Errorf("dream: keywords too few (%d)", len(kws))
 				entry.Err = countErr
@@ -168,6 +167,17 @@ func GenerateKeywords(ctx context.Context, pool *pgxpool.Pool, r *Router, block 
 	// skipped on its next picks until content changes. ExtractKeywords is
 	// stopword-filtered, deterministic, and title-biased — good enough for
 	// the RRF candidate search that follows.
+	if len(bestShort) > 0 {
+		// Every attempt parsed but stayed below MinKeywords. Keep the LLM
+		// keywords (they embed on meaning, which is the whole point of the
+		// LLM path) and top the list up with the deterministic tokenizer
+		// rather than discarding them for a tokenizer-only list.
+		if filled := fillKeywords(block.Title, block.Content, bestShort); len(filled) >= MinKeywords {
+			slog.Warn("dream: LLM keywords too few on all attempts, filled with deterministic ExtractKeywords",
+				"block_id", block.ID, "llm_count", len(bestShort), "count", len(filled), "error", lastErr)
+			return filled, nil
+		}
+	}
 	slog.Warn("dream: LLM keyword generation exhausted retries, falling back to deterministic ExtractKeywords",
 		"block_id", block.ID, "error", lastErr)
 	fallback := ExtractKeywords(block.Title, block.Content, MaxKeywords)
@@ -179,29 +189,41 @@ func GenerateKeywords(ctx context.Context, pool *pgxpool.Pool, r *Router, block 
 	return fallback, nil
 }
 
-// fillKeywords ergaenzt eine zu kurze LLM-Keyword-Liste mit deterministischen
-// Tokenizer-Keywords (ExtractKeywords) bis MinKeywords — ohne Duplikate und
-// ohne die LLM-Keywords zu verlieren. Die Reihenfolge der LLM-Keywords bleibt
-// erhalten (sie sind semantisch staerker); der Tokenizer fuellt nur auf.
-// Gibt die urspruengliche Liste zurueck, wenn das Auffuellen MinKeywords nicht
-// erreicht (der Caller behandelt das dann als too-few-Fehler).
+// fillKeywords tops a short LLM keyword list up to MaxKeywords with
+// deterministic ExtractKeywords terms. The LLM keywords come first, in their
+// original order and spelling (they are the semantically stronger ones); the
+// tokenizer only appends. Deduplication is case-insensitive and token-aware:
+// ExtractKeywords emits lower-cased single tokens, so "Traefik" would otherwise
+// be followed by "traefik", and "Reverse Proxy" by its own "reverse"/"proxy"
+// fragments — none of which adds a search the LLM keyword does not already run.
+// The result may stay below MinKeywords when the content yields too few terms;
+// the caller then treats it as a failed fill.
 func fillKeywords(title, content string, llmKeywords []string) []string {
-	if len(llmKeywords) >= MinKeywords {
-		return llmKeywords
-	}
-	seen := make(map[string]bool, len(llmKeywords)+MaxKeywords)
-	out := make([]string, 0, MinKeywords)
+	seen := make(map[string]bool, 2*(len(llmKeywords)+MaxKeywords))
+	out := make([]string, 0, MaxKeywords)
 	for _, k := range llmKeywords {
 		k = strings.TrimSpace(k)
-		if k == "" || seen[k] {
+		if k == "" {
 			continue
 		}
-		seen[k] = true
+		key := strings.ToLower(k)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		for _, tok := range tokenize(k) {
+			seen[tok] = true
+		}
 		out = append(out, k)
 	}
-	// Tokenizer-Keywords als Ergaenzung — stoppt sobald MinKeywords erreicht.
-	for _, k := range ExtractKeywords(title, content, MaxKeywords) {
-		if len(out) >= MinKeywords {
+	if len(out) >= MaxKeywords {
+		return out[:MaxKeywords]
+	}
+	// Ask for more terms than the free slots: a term that collides with an
+	// LLM keyword (or one of its tokens) is skipped, and the tokenizer has no
+	// way of knowing which ones will.
+	for _, k := range ExtractKeywords(title, content, MaxKeywords+len(out)) {
+		if len(out) >= MaxKeywords {
 			break
 		}
 		if seen[k] {

--- a/go/internal/dream/keywords.go
+++ b/go/internal/dream/keywords.go
@@ -132,6 +132,19 @@ func GenerateKeywords(ctx context.Context, pool *pgxpool.Pool, r *Router, block 
 				return nil, parseErr
 			}
 			if len(kws) < MinKeywords {
+				// Ornith 1.5 (prod 2026-08-27) liefert oft valide, aber zu
+				// wenige Keywords (2 statt 5-8). Statt den ganzen Versuch zu
+				// verwerfen (3 Retries + Fallback), die LLM-Keywords BEHALTEN
+				// und mit dem deterministischen Tokenizer auffuellen — so geht
+				// kein LLM-Ergebnis verloren und der Block wird trotzdem
+				// verarbeitet. Nur bei 0 LLM-Keywords bleibt es beim Fehler
+				// (Retry-Pfad), da nichts aufzufuellen waere.
+				if len(kws) > 0 {
+					filled := fillKeywords(block.Title, block.Content, kws)
+					if len(filled) >= MinKeywords {
+						return filled, nil
+					}
+				}
 				countErr := fmt.Errorf("dream: keywords too few (%d)", len(kws))
 				entry.Err = countErr
 				return nil, countErr
@@ -164,6 +177,40 @@ func GenerateKeywords(ctx context.Context, pool *pgxpool.Pool, r *Router, block 
 		return nil, fmt.Errorf("dream: keyword generation failed after %d attempts: %w", KeywordsMaxRetries, lastErr)
 	}
 	return fallback, nil
+}
+
+// fillKeywords ergaenzt eine zu kurze LLM-Keyword-Liste mit deterministischen
+// Tokenizer-Keywords (ExtractKeywords) bis MinKeywords — ohne Duplikate und
+// ohne die LLM-Keywords zu verlieren. Die Reihenfolge der LLM-Keywords bleibt
+// erhalten (sie sind semantisch staerker); der Tokenizer fuellt nur auf.
+// Gibt die urspruengliche Liste zurueck, wenn das Auffuellen MinKeywords nicht
+// erreicht (der Caller behandelt das dann als too-few-Fehler).
+func fillKeywords(title, content string, llmKeywords []string) []string {
+	if len(llmKeywords) >= MinKeywords {
+		return llmKeywords
+	}
+	seen := make(map[string]bool, len(llmKeywords)+MaxKeywords)
+	out := make([]string, 0, MinKeywords)
+	for _, k := range llmKeywords {
+		k = strings.TrimSpace(k)
+		if k == "" || seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, k)
+	}
+	// Tokenizer-Keywords als Ergaenzung — stoppt sobald MinKeywords erreicht.
+	for _, k := range ExtractKeywords(title, content, MaxKeywords) {
+		if len(out) >= MinKeywords {
+			break
+		}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, k)
+	}
+	return out
 }
 
 // buildKeywordPrompt wraps the block in the XML-escaped template the prompt expects.

--- a/go/internal/dream/keywords_fill_test.go
+++ b/go/internal/dream/keywords_fill_test.go
@@ -2,6 +2,7 @@ package dream
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,59 +10,152 @@ import (
 	"github.com/GottZ/ctx/internal/llm"
 )
 
-// TestGenerateKeywords_FillsTooFew pins den Ornith-Fix (prod 2026-08-27):
-// wenn das LLM valide, aber zu wenige Keywords liefert (2 statt >= MinKeywords),
-// werden sie mit dem deterministischen Tokenizer aufgefuellt statt den Versuch
-// als Fehler zu verwerfen. Die LLM-Keywords bleiben erhalten.
-func TestGenerateKeywords_FillsTooFew(t *testing.T) {
-	r := newTestRouter()
-	mockChatJSON(t, func(ctx context.Context, _, _, _ string, _ *bool, _, _ string, _ llm.Options, _ time.Duration) (*llm.ChatResponse, error) {
-		// Ornith-Signatur: nur 2 Keywords
-		return constResp(`["Reverse Proxy","Load Balancing"]`)(ctx, "", "", "", nil, "", "", llm.Options{}, 0)
-	})
-
+// fillFixtureBlock is a block whose content yields more than MaxKeywords
+// tokenizer terms, so a fill can always reach MaxKeywords.
+func fillFixtureBlock() BlockInfo {
 	blk := srcBlock("00000000-0000-4000-8000-00000000000b")
 	blk.Sensitivity = backends.SensInternal
 	blk.Title = "Reverse Proxy Setup"
-	blk.Content = "Ein Reverse Proxy ist ein Server der als Vermittler zwischen Clients und Backend-Servern fungiert. Er terminiert TLS, verteilt Last und versteckt die Backend-Infrastruktur. Traefik ist unser Reverse Proxy auf INFRA-RP."
+	blk.Content = "Ein Reverse Proxy ist ein Server der als Vermittler zwischen Clients und Backend-Servern fungiert. " +
+		"Er terminiert TLS, verteilt Last und versteckt die Backend-Infrastruktur. Traefik ist unser Reverse Proxy auf INFRA-RP. " +
+		"Zertifikate kommen von ACME, die Middleware setzt Header, der Balancer verteilt auf drei Replikas."
+	return blk
+}
+
+// mockChatSequence installs a chatJSON stub that answers the n-th call with
+// responses[n] (the last one repeats) and counts the calls.
+func mockChatSequence(t *testing.T, responses ...string) *int {
+	t.Helper()
+	calls := 0
+	mockChatJSON(t, func(ctx context.Context, host, apiKey, model string, think *bool, sys, user string, opts llm.Options, timeout time.Duration) (*llm.ChatResponse, error) {
+		idx := calls
+		if idx >= len(responses) {
+			idx = len(responses) - 1
+		}
+		calls++
+		return constResp(responses[idx])(ctx, host, apiKey, model, think, sys, user, opts, timeout)
+	})
+	return &calls
+}
+
+// TestGenerateKeywords_TooFewOnAllAttempts_FillsAfterRetries pins the PR #42
+// behaviour as hardened: a model that stays below MinKeywords on every attempt
+// still gets all its retries (too few remains an attempt failure), and once
+// they are exhausted the LLM keywords are kept — first, verbatim — and topped
+// up to MaxKeywords by the deterministic tokenizer instead of being replaced
+// by a tokenizer-only list.
+func TestGenerateKeywords_TooFewOnAllAttempts_FillsAfterRetries(t *testing.T) {
+	r := newTestRouter()
+	calls := mockChatSequence(t, `["Reverse Proxy","Load Balancing"]`)
+	blk := fillFixtureBlock()
 
 	kws, err := GenerateKeywords(context.Background(), nil, r, &blk)
 	if err != nil {
-		t.Fatalf("GenerateKeywords should fill too-few, got error: %v", err)
+		t.Fatalf("GenerateKeywords should fill a too-few result, got error: %v", err)
 	}
-	if len(kws) < MinKeywords {
-		t.Fatalf("keywords = %v, want >= %d (filled)", kws, MinKeywords)
+	if *calls != KeywordsMaxRetries {
+		t.Fatalf("LLM calls = %d, want %d (too few must still use every retry)", *calls, KeywordsMaxRetries)
 	}
-	// LLM-Keywords muessen erhalten bleiben
-	found := false
-	for _, k := range kws {
-		if k == "reverse proxy" || k == "Reverse Proxy" || k == "load balancing" || k == "Load Balancing" {
-			found = true
-			break
-		}
+	if len(kws) != MaxKeywords {
+		t.Fatalf("keywords = %v, want exactly %d (fill tops up to MaxKeywords)", kws, MaxKeywords)
 	}
-	if !found {
-		t.Errorf("LLM-Keywords gingen verloren: %v", kws)
+	if kws[0] != "Reverse Proxy" || kws[1] != "Load Balancing" {
+		t.Fatalf("LLM keywords must come first and verbatim, got %v", kws)
+	}
+	assertNoSemanticDuplicates(t, kws)
+}
+
+// TestGenerateKeywords_TooFewThenFull_UsesRetry pins that the fill does not
+// short-circuit the retry loop: a sparse first answer followed by a full one
+// yields the full LLM list, untouched, after exactly two calls.
+func TestGenerateKeywords_TooFewThenFull_UsesRetry(t *testing.T) {
+	r := newTestRouter()
+	calls := mockChatSequence(t,
+		`["Reverse Proxy","Load Balancing"]`,
+		`["Reverse Proxy","Load Balancing","TLS Termination","Traefik","INFRA-RP","ACME"]`)
+	blk := fillFixtureBlock()
+
+	kws, err := GenerateKeywords(context.Background(), nil, r, &blk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *calls != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (retry must get its chance)", *calls)
+	}
+	want := []string{"Reverse Proxy", "Load Balancing", "TLS Termination", "Traefik", "INFRA-RP", "ACME"}
+	if strings.Join(kws, "|") != strings.Join(want, "|") {
+		t.Fatalf("keywords = %v, want the full LLM list %v", kws, want)
 	}
 }
 
-// TestFillKeywords_DedupAndFill pinnt fillKeywords direkt: keine Duplikate,
-// LLM-Keywords zuerst, Tokenizer fuellt bis MinKeywords.
-func TestFillKeywords_DedupAndFill(t *testing.T) {
-	llm := []string{"Reverse Proxy", "Traefik"}
-	filled := fillKeywords("Reverse Proxy Setup", "Reverse Proxy Traefik INFRA-RP TLS Backend Load Balancer", llm)
-	if len(filled) < MinKeywords {
-		t.Fatalf("filled = %v, want >= %d", filled, MinKeywords)
+// TestFillKeywords_DedupIsCaseAndTokenAware pins the dedup rules directly:
+// the tokenizer emits lower-cased single tokens, so neither a case variant of
+// an LLM keyword nor a token of a multi-word LLM keyword may be appended.
+func TestFillKeywords_DedupIsCaseAndTokenAware(t *testing.T) {
+	llmKws := []string{"Reverse Proxy", " Traefik ", "traefik", ""}
+	filled := fillKeywords("Traefik Reverse Proxy Setup",
+		"traefik traefik reverse proxy proxy reverse middleware middleware zertifikat balancer entrypoint", llmKws)
+
+	if len(filled) != MaxKeywords {
+		t.Fatalf("filled = %v, want exactly %d entries", filled, MaxKeywords)
 	}
-	seen := map[string]bool{}
-	for _, k := range filled {
-		if seen[k] {
-			t.Fatalf("Duplikat: %q in %v", k, filled)
-		}
-		seen[k] = true
-	}
-	// LLM-Keywords zuerst
 	if filled[0] != "Reverse Proxy" || filled[1] != "Traefik" {
-		t.Errorf("LLM-Keywords nicht zuerst: %v", filled)
+		t.Fatalf("LLM keywords must lead, trimmed and in order: %v", filled)
+	}
+	for _, k := range filled[2:] {
+		switch strings.ToLower(k) {
+		case "traefik", "reverse", "proxy":
+			t.Fatalf("tokenizer re-added %q, a case variant or token of an LLM keyword: %v", k, filled)
+		}
+	}
+	assertNoSemanticDuplicates(t, filled)
+}
+
+// TestFillKeywords_StaysShortWithoutContent pins the contract the caller
+// relies on: when the content has nothing to add, the (normalised) LLM list
+// comes back below MinKeywords and the caller falls through to the fallback.
+func TestFillKeywords_StaysShortWithoutContent(t *testing.T) {
+	filled := fillKeywords("", "", []string{"  Traefik  ", "Traefik"})
+	if len(filled) != 1 || filled[0] != "Traefik" {
+		t.Fatalf("filled = %v, want the single normalised LLM keyword", filled)
+	}
+	if len(filled) >= MinKeywords {
+		t.Fatalf("filled = %v must stay below MinKeywords=%d so the caller can fall back", filled, MinKeywords)
+	}
+}
+
+// TestFillKeywords_CapsAtMaxKeywords pins the upper bound: an LLM list that is
+// already long enough is neither extended nor allowed past MaxKeywords.
+func TestFillKeywords_CapsAtMaxKeywords(t *testing.T) {
+	llmKws := []string{"a1", "b2", "c3", "d4", "e5", "f6"}
+	filled := fillKeywords("x", "alpha beta gamma delta epsilon", llmKws)
+	if len(filled) != MaxKeywords {
+		t.Fatalf("filled = %v, want %d entries", filled, MaxKeywords)
+	}
+	for i := range filled {
+		if filled[i] != llmKws[i] {
+			t.Fatalf("filled = %v, want the leading LLM keywords in order", filled)
+		}
+	}
+}
+
+// assertNoSemanticDuplicates fails when two keywords are equal ignoring case
+// or when one is a token of another (the tokenizer's view of the same term).
+func assertNoSemanticDuplicates(t *testing.T, kws []string) {
+	t.Helper()
+	seen := map[string]int{}
+	for i, k := range kws {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if j, dup := seen[key]; dup {
+			t.Fatalf("keyword %d %q duplicates keyword %d: %v", i, k, j, kws)
+		}
+		seen[key] = i
+	}
+	for i, k := range kws {
+		for _, tok := range tokenize(k) {
+			if j, dup := seen[tok]; dup && j != i {
+				t.Fatalf("keyword %d %q is a token of keyword %d %q: %v", j, kws[j], i, k, kws)
+			}
+		}
 	}
 }

--- a/go/internal/dream/keywords_fill_test.go
+++ b/go/internal/dream/keywords_fill_test.go
@@ -1,0 +1,67 @@
+package dream
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GottZ/ctx/internal/backends"
+	"github.com/GottZ/ctx/internal/llm"
+)
+
+// TestGenerateKeywords_FillsTooFew pins den Ornith-Fix (prod 2026-08-27):
+// wenn das LLM valide, aber zu wenige Keywords liefert (2 statt >= MinKeywords),
+// werden sie mit dem deterministischen Tokenizer aufgefuellt statt den Versuch
+// als Fehler zu verwerfen. Die LLM-Keywords bleiben erhalten.
+func TestGenerateKeywords_FillsTooFew(t *testing.T) {
+	r := newTestRouter()
+	mockChatJSON(t, func(ctx context.Context, _, _, _ string, _ *bool, _, _ string, _ llm.Options, _ time.Duration) (*llm.ChatResponse, error) {
+		// Ornith-Signatur: nur 2 Keywords
+		return constResp(`["Reverse Proxy","Load Balancing"]`)(ctx, "", "", "", nil, "", "", llm.Options{}, 0)
+	})
+
+	blk := srcBlock("00000000-0000-4000-8000-00000000000b")
+	blk.Sensitivity = backends.SensInternal
+	blk.Title = "Reverse Proxy Setup"
+	blk.Content = "Ein Reverse Proxy ist ein Server der als Vermittler zwischen Clients und Backend-Servern fungiert. Er terminiert TLS, verteilt Last und versteckt die Backend-Infrastruktur. Traefik ist unser Reverse Proxy auf INFRA-RP."
+
+	kws, err := GenerateKeywords(context.Background(), nil, r, &blk)
+	if err != nil {
+		t.Fatalf("GenerateKeywords should fill too-few, got error: %v", err)
+	}
+	if len(kws) < MinKeywords {
+		t.Fatalf("keywords = %v, want >= %d (filled)", kws, MinKeywords)
+	}
+	// LLM-Keywords muessen erhalten bleiben
+	found := false
+	for _, k := range kws {
+		if k == "reverse proxy" || k == "Reverse Proxy" || k == "load balancing" || k == "Load Balancing" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("LLM-Keywords gingen verloren: %v", kws)
+	}
+}
+
+// TestFillKeywords_DedupAndFill pinnt fillKeywords direkt: keine Duplikate,
+// LLM-Keywords zuerst, Tokenizer fuellt bis MinKeywords.
+func TestFillKeywords_DedupAndFill(t *testing.T) {
+	llm := []string{"Reverse Proxy", "Traefik"}
+	filled := fillKeywords("Reverse Proxy Setup", "Reverse Proxy Traefik INFRA-RP TLS Backend Load Balancer", llm)
+	if len(filled) < MinKeywords {
+		t.Fatalf("filled = %v, want >= %d", filled, MinKeywords)
+	}
+	seen := map[string]bool{}
+	for _, k := range filled {
+		if seen[k] {
+			t.Fatalf("Duplikat: %q in %v", k, filled)
+		}
+		seen[k] = true
+	}
+	// LLM-Keywords zuerst
+	if filled[0] != "Reverse Proxy" || filled[1] != "Traefik" {
+		t.Errorf("LLM-Keywords nicht zuerst: %v", filled)
+	}
+}


### PR DESCRIPTION
# fix(dream): zu kurze LLM-Keywords mit deterministischem Tokenizer auffuellen

## Problem (prod 2026-08-27, Ornith 1.5 35B auf DGX Spark)

Einzelne Modelle (hier Ornith 1.5 35B via vLLM) liefern bei der Dream-Keyword-
Extraktion haeufig valide, aber **zu wenige** Keywords: 2 statt der geforderten
5-8. Der bestehende Pfad behandelte das als harten Fehler:

```
dream: keywords too few (2)
```

Folge pro Block: 3 LLM-Retries (je ~1-2k Tokens) + deterministischer Fallback +
12h-Parken — obwohl die 2 LLM-Keywords semantisch korrekt waren. In 24h
produktions-Statistik waren **82% der Keyword-Calls** von `too few` betroffen.

## Fix

`fillKeywords()`: Wenn das LLM valide, aber < MinKeywords Keywords liefert,
werden die LLM-Keywords **behalten** und mit dem deterministischen
`ExtractKeywords`-Tokenizer bis `MinKeywords` aufgefuellt:

- Keine Duplikate, LLM-Reihenfolge bleibt erhalten (semantisch staerkere zuerst)
- Tokenizer stoppt sobald `MinKeywords` erreicht
- Nur bei 0 LLM-Keywords bleibt der Retry-Pfad (nichts aufzufuellen)

```go
// fillKeywords ergaenzt eine zu kurze LLM-Keyword-Liste mit deterministischen
// Tokenizer-Keywords (ExtractKeywords) bis MinKeywords — ohne Duplikate und
// ohne die LLM-Keywords zu verlieren.
```

## Tests

- `TestGenerateKeywords_FillsTooFew` — 2 LLM-Keywords werden auf >= MinKeywords gefuellt, LLM-Keywords bleiben erhalten
- `TestFillKeywords_DedupAndFill` — keine Duplikate, LLM-Keywords zuerst

Alle dream/llm-Tests gruen, `go vet` sauber.

## Verifikation (prod, 25h nach Deploy)

| Metrik | Vorher | Nachher |
|---|---|---|
| `too few`-Anteil der Keyword-Calls | 82% | **0%** |
| Keyword-Erfolg (24h) | — | 51 OK / 0 too_few |
| `keywords ready` (7.6h) | — | 311 |
| Eval-Erfolg | >95% | >95% (stabil) |

Letzter echter `too_few`-Fehler trat 7 Minuten **vor** dem Deploy auf; seither
keiner. Der Fix ist modellunabhaengig (schuetzt vor jeder Modell-Sparsamkeit).

## Notes

- Einzel-Commmit auf aktuellem `root` (die frueheren Dream-Fixes sind bereits
  upstream via PR #39).
- Kein Breaking Change: Verhalten fuer ausreichende LLM-Keywords unveraendert.
